### PR TITLE
Default `series` for when Influx doesn't return it

### DIFF
--- a/influxdb/src/integrations/serde_integration.rs
+++ b/influxdb/src/integrations/serde_integration.rs
@@ -80,6 +80,7 @@ impl DatabaseQueryResult {
 #[derive(Deserialize, Debug)]
 #[doc(hidden)]
 pub struct Return<T> {
+    #[serde(default = "Vec::new")]
     pub series: Vec<Series<T>>,
 }
 


### PR DESCRIPTION
## Description

If there is no data to return, the `"series"` key is omitted from the InfluxDB response. As such, defaulting to `Vec::new` makes sense.

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment