### PR TITLE
Remove <dyn Query> warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,9 +27,9 @@ jobs:
             - name: Check code formatting
               run: cargo fmt --all -- --check
             - name: Check Clippy lints (reqwest)
-              run: cargo clippy --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings
+              run: cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings
             - name: Check Clippy lints (surf)
-              run: cargo clippy --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings
+              run: cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings
 
     compile:
         name: Compile (${{ matrix.rust_release }}/${{ matrix.os }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - reqwest-based http client (enabled by default)
+- deprecate `<dyn Query>::raw_read_query` in favour of `ReadQuery::new`
 
 ## [0.4.0] - 2021-03-08
 

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use influxdb::Error;
 use influxdb::InfluxDbWriteable;
-use influxdb::{Client, Query};
+use influxdb::{Client, ReadQuery};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc::unbounded_channel;
@@ -67,7 +67,7 @@ async fn main() {
 async fn prepare_influxdb(client: &Client, db_name: &str) {
     let create_db_stmt = format!("CREATE DATABASE {}", db_name);
     client
-        .query(&Query::raw_read_query(create_db_stmt))
+        .query(&ReadQuery::new(create_db_stmt))
         .await
         .expect("failed to create database");
 }

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -108,6 +108,7 @@
 
 #![allow(clippy::needless_doctest_main)]
 #![allow(clippy::needless_lifetimes)] // False positive in client/mod.rs query fn
+#![forbid(bare_trait_objects)]
 
 #[cfg(all(feature = "reqwest", feature = "surf"))]
 compile_error!("You need to choose between reqwest and surf; enabling both is not supported");

--- a/influxdb/src/query/mod.rs
+++ b/influxdb/src/query/mod.rs
@@ -135,6 +135,7 @@ impl dyn Query {
     ///
     /// Query::raw_read_query("SELECT * FROM weather"); // Is of type [`ReadQuery`](crate::ReadQuery)
     /// ```
+    #[deprecated(since = "0.5.0", note = "Use ReadQuery::new instead")]
     pub fn raw_read_query<S>(read_query: S) -> ReadQuery
     where
         S: Into<String>,

--- a/influxdb/src/query/read_query.rs
+++ b/influxdb/src/query/read_query.rs
@@ -43,18 +43,18 @@ impl Query for ReadQuery {
 
 #[cfg(test)]
 mod tests {
-    use crate::query::{Query, QueryType};
+    use crate::query::{Query, QueryType, ReadQuery};
 
     #[test]
     fn test_read_builder_single_query() {
-        let query = Query::raw_read_query("SELECT * FROM aachen").build();
+        let query = ReadQuery::new("SELECT * FROM aachen").build();
 
         assert_eq!(query.unwrap(), "SELECT * FROM aachen");
     }
 
     #[test]
     fn test_read_builder_multi_query() {
-        let query = Query::raw_read_query("SELECT * FROM aachen")
+        let query = ReadQuery::new("SELECT * FROM aachen")
             .add_query("SELECT * FROM cologne")
             .build();
 
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     fn test_correct_query_type() {
-        let query = Query::raw_read_query("SELECT * FROM aachen");
+        let query = ReadQuery::new("SELECT * FROM aachen");
 
         assert_eq!(query.get_type(), QueryType::ReadQuery);
     }

--- a/influxdb/src/query/write_query.rs
+++ b/influxdb/src/query/write_query.rs
@@ -334,7 +334,6 @@ mod tests {
 
         assert!(query.is_ok(), "Query was empty");
         let query_res = query.unwrap().get();
-        #[allow(clippy::print_literal)]
         assert_eq!(
             query_res,
             r#"wea\,\ ther=,location=us-midwest,loc\,\ \="ation=us\,\ \"mid\=west temperature=82i,"temp\=era\,t\ ure"="too\"\\\\hot",float=82 11"#

--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -5,7 +5,7 @@ mod utilities;
 use influxdb::InfluxDbWriteable;
 
 use chrono::{DateTime, Utc};
-use influxdb::{Query, Timestamp};
+use influxdb::{Query, ReadQuery, Timestamp};
 
 #[cfg(feature = "use-serde")]
 use serde::Deserialize;
@@ -101,8 +101,7 @@ async fn test_write_and_read_option() {
                 .query(&weather_reading.into_query("weather_reading".to_string()))
                 .await;
             assert_result_ok(&write_result);
-            let query =
-                Query::raw_read_query("SELECT time, pressure, wind_strength FROM weather_reading");
+            let query = ReadQuery::new("SELECT time, pressure, wind_strength FROM weather_reading");
             let result = client.json_query(query).await.and_then(|mut db_result| {
                 println!("{:?}", db_result);
                 db_result.deserialize_next::<WeatherReadingWithoutIgnored>()

--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -108,8 +108,10 @@ async fn test_write_and_read_option() {
             });
             assert_result_ok(&result);
             let result = result.unwrap();
-            assert_eq!(result.series[0].values[0].pressure, 100);
-            assert_eq!(result.series[0].values[0].wind_strength, None);
+            let value = &result.series[0].values[0];
+            assert_eq!(value.time, Timestamp::Hours(11).into());
+            assert_eq!(value.pressure, 100);
+            assert_eq!(value.wind_strength, None);
         },
         || async move {
             delete_db(TEST_NAME).await.expect("could not clean up db");

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -7,7 +7,7 @@ use utilities::{
 };
 
 use influxdb::InfluxDbWriteable;
-use influxdb::{Client, Error, Query, Timestamp};
+use influxdb::{Client, Error, ReadQuery, Timestamp};
 
 /// INTEGRATION TEST
 ///
@@ -52,7 +52,7 @@ async fn test_connection_error() {
     let test_name = "test_connection_error";
     let client =
         Client::new("http://127.0.0.1:10086", test_name).with_auth("nopriv_user", "password");
-    let read_query = Query::raw_read_query("SELECT * FROM weather");
+    let read_query = ReadQuery::new("SELECT * FROM weather");
     let read_result = client.query(&read_query).await;
     assert_result_err(&read_result);
     match read_result {
@@ -78,7 +78,7 @@ async fn test_authed_write_and_read() {
                 Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("CREATE DATABASE {}", TEST_NAME);
             client
-                .query(&Query::raw_read_query(query))
+                .query(&ReadQuery::new(query))
                 .await
                 .expect("could not setup db");
 
@@ -90,7 +90,7 @@ async fn test_authed_write_and_read() {
             let write_result = client.query(&write_query).await;
             assert_result_ok(&write_result);
 
-            let read_query = Query::raw_read_query("SELECT * FROM weather");
+            let read_query = ReadQuery::new("SELECT * FROM weather");
             let read_result = client.query(&read_query).await;
             assert_result_ok(&read_result);
             assert!(
@@ -104,7 +104,7 @@ async fn test_authed_write_and_read() {
             let query = format!("DROP DATABASE {}", TEST_NAME);
 
             client
-                .query(&Query::raw_read_query(query))
+                .query(&ReadQuery::new(query))
                 .await
                 .expect("could not clean up db");
         },
@@ -126,7 +126,7 @@ async fn test_wrong_authed_write_and_read() {
                 Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("CREATE DATABASE {}", TEST_NAME);
             client
-                .query(&Query::raw_read_query(query))
+                .query(&ReadQuery::new(query))
                 .await
                 .expect("could not setup db");
 
@@ -145,7 +145,7 @@ async fn test_wrong_authed_write_and_read() {
                 ),
             }
 
-            let read_query = Query::raw_read_query("SELECT * FROM weather");
+            let read_query = ReadQuery::new("SELECT * FROM weather");
             let read_result = client.query(&read_query).await;
             assert_result_err(&read_result);
             match read_result {
@@ -158,7 +158,7 @@ async fn test_wrong_authed_write_and_read() {
 
             let client = Client::new("http://127.0.0.1:9086", TEST_NAME)
                 .with_auth("nopriv_user", "password");
-            let read_query = Query::raw_read_query("SELECT * FROM weather");
+            let read_query = ReadQuery::new("SELECT * FROM weather");
             let read_result = client.query(&read_query).await;
             assert_result_err(&read_result);
             match read_result {
@@ -174,7 +174,7 @@ async fn test_wrong_authed_write_and_read() {
                 Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("DROP DATABASE {}", TEST_NAME);
             client
-                .query(&Query::raw_read_query(query))
+                .query(&ReadQuery::new(query))
                 .await
                 .expect("could not clean up db");
         },
@@ -196,7 +196,7 @@ async fn test_non_authed_write_and_read() {
                 Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("CREATE DATABASE {}", TEST_NAME);
             client
-                .query(&Query::raw_read_query(query))
+                .query(&ReadQuery::new(query))
                 .await
                 .expect("could not setup db");
             let non_authed_client = Client::new("http://127.0.0.1:9086", TEST_NAME);
@@ -213,7 +213,7 @@ async fn test_non_authed_write_and_read() {
                 ),
             }
 
-            let read_query = Query::raw_read_query("SELECT * FROM weather");
+            let read_query = ReadQuery::new("SELECT * FROM weather");
             let read_result = non_authed_client.query(&read_query).await;
             assert_result_err(&read_result);
             match read_result {
@@ -229,7 +229,7 @@ async fn test_non_authed_write_and_read() {
                 Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("DROP DATABASE {}", TEST_NAME);
             client
-                .query(&Query::raw_read_query(query))
+                .query(&ReadQuery::new(query))
                 .await
                 .expect("could not clean up db");
         },
@@ -255,7 +255,7 @@ async fn test_write_and_read_field() {
             let write_result = client.query(&write_query).await;
             assert_result_ok(&write_result);
 
-            let read_query = Query::raw_read_query("SELECT * FROM weather");
+            let read_query = ReadQuery::new("SELECT * FROM weather");
             let read_result = client.query(&read_query).await;
             assert_result_ok(&read_result);
             assert!(
@@ -304,8 +304,7 @@ async fn test_write_and_read_option() {
                     temperature: i32,
                 }
 
-                let query =
-                    Query::raw_read_query("SELECT time, temperature, wind_strength FROM weather");
+                let query = ReadQuery::new("SELECT time, temperature, wind_strength FROM weather");
                 let result = client
                     .json_query(query)
                     .await
@@ -361,7 +360,7 @@ async fn test_json_query() {
                 temperature: i32,
             }
 
-            let query = Query::raw_read_query("SELECT * FROM weather");
+            let query = ReadQuery::new("SELECT * FROM weather");
             let result = client
                 .json_query(query)
                 .await
@@ -419,7 +418,7 @@ async fn test_json_query_tagged() {
                 temperature: i32,
             }
 
-            let query = Query::raw_read_query("SELECT * FROM weather GROUP BY location");
+            let query = ReadQuery::new("SELECT * FROM weather GROUP BY location");
             let result = client.json_query(query).await.and_then(|mut db_result| {
                 db_result.deserialize_next_tagged::<WeatherMeta, Weather>()
             });
@@ -487,7 +486,7 @@ async fn test_json_query_vec() {
                 temperature: i32,
             }
 
-            let query = Query::raw_read_query("SELECT * FROM temperature_vec");
+            let query = ReadQuery::new("SELECT * FROM temperature_vec");
             let result = client
                 .json_query(query)
                 .await
@@ -544,8 +543,7 @@ async fn test_serde_multi_query() {
 
             let result = client
                 .json_query(
-                    Query::raw_read_query("SELECT * FROM temperature")
-                        .add_query("SELECT * FROM humidity"),
+                    ReadQuery::new("SELECT * FROM temperature").add_query("SELECT * FROM humidity"),
                 )
                 .await
                 .and_then(|mut db_result| {
@@ -588,7 +586,7 @@ async fn test_serde_multi_query() {
 async fn test_wrong_query_errors() {
     let client = create_client("test_name");
     let result = client
-        .json_query(Query::raw_read_query("CREATE DATABASE this_should_fail"))
+        .json_query(ReadQuery::new("CREATE DATABASE this_should_fail"))
         .await;
     assert!(
         result.is_err(),

--- a/influxdb/tests/utilities.rs
+++ b/influxdb/tests/utilities.rs
@@ -1,5 +1,5 @@
 use futures::prelude::*;
-use influxdb::{Client, Error, Query};
+use influxdb::{Client, Error, ReadQuery};
 use std::panic::{AssertUnwindSafe, UnwindSafe};
 
 #[allow(dead_code)]
@@ -28,9 +28,7 @@ where
 {
     let test_name = name.into();
     let query = format!("CREATE DATABASE {}", test_name);
-    create_client(test_name)
-        .query(&Query::raw_read_query(query))
-        .await
+    create_client(test_name).query(&ReadQuery::new(query)).await
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -40,9 +38,7 @@ where
 {
     let test_name = name.into();
     let query = format!("DROP DATABASE {}", test_name);
-    create_client(test_name)
-        .query(&Query::raw_read_query(query))
-        .await
+    create_client(test_name).query(&ReadQuery::new(query)).await
 }
 
 #[cfg(not(tarpaulin_include))]


### PR DESCRIPTION
## Description

Remove `<dyn Query>` warnings and all other warnings that currently make influxdb fail CI.

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment