### PR TITLE
PR template clippy surf OR reqwest

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,8 @@
 ### Checklist
 - [ ] Formatted code using `cargo fmt --all`
 - [ ] Linted code using clippy
-  - [ ] surf based features `cd influxdb;cargo clippy --all-targets --no-default-features --features derive,use-serde,curl-client,h1-client,h1-client-rustls,hyper-client,wasm-client -- -D warnings;cd ..`
-  - [ ] reqwest based features `cargo clippy --all-targets --features derive,use-serde,reqwest-client,reqwest-client-rustls -- -D warnings`
+  - [ ] surf based features `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
+  - [ ] reqwest based features `cargo clippy --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
 - [ ] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
 - [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
 - [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,8 @@
 ### Checklist
 - [ ] Formatted code using `cargo fmt --all`
 - [ ] Linted code using clippy
-  - [ ] surf based features `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
-  - [ ] reqwest based features `cargo clippy --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
+  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
+  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
 - [ ] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
 - [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
 - [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,9 @@
 
 ### Checklist
 - [ ] Formatted code using `cargo fmt --all`
-- [ ] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] Linted code using clippy
+  - [ ] surf based features `cd influxdb;cargo clippy --all-targets --no-default-features --features derive,use-serde,curl-client,h1-client,h1-client-rustls,hyper-client,wasm-client -- -D warnings;cd ..`
+  - [ ] reqwest based features `cargo clippy --all-targets --features derive,use-serde,reqwest-client,reqwest-client-rustls -- -D warnings`
 - [ ] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
 - [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
 - [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment


### PR DESCRIPTION
## Description

PR Template check of `cargo clippy --all-targets --all-features -- -D warnings` errors due to --all-features importing both surf and reqwest. Split into two separate checks.

### Checklist
- [X] Formatted code using `cargo fmt --all`
- [X] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [X] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [X] Reviewed the diff. Did you leave any print statements or unnecessary comments?
  - The last line change is adding a newline at the end of the file.
- [X] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment