### PR TITLE
Replace futures dependency with futures-util

### DIFF
--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/influxdb-rs/influxdb-rust"
 
 [dependencies]
 chrono = { version = "0.4.11", features = ["serde"] }
-futures = "0.3.4"
+futures-util = "0.3.17"
 http = "0.2.4"
 influxdb_derive = { version = "0.4.0", optional = true }
 lazy_static = "1.4.0"

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -15,7 +15,7 @@
 //! assert_eq!(client.database_name(), "test");
 //! ```
 
-use futures::prelude::*;
+use futures_util::TryFutureExt;
 use http::StatusCode;
 #[cfg(feature = "reqwest")]
 use reqwest::{Client as HttpClient, Response as HttpResponse};

--- a/influxdb/src/integrations/serde_integration/mod.rs
+++ b/influxdb/src/integrations/serde_integration/mod.rs
@@ -7,7 +7,6 @@
 //! `name`, InfluxDB provides alongside query results.
 //!
 //! ```rust,no_run
-//! use futures::prelude::*;
 //! use influxdb::{Client, Query};
 //! use serde::Deserialize;
 //!

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -56,7 +56,7 @@
 //!     assert!(write_result.is_ok(), "Write result was not okay");
 //!
 //!     // Let's see if the data we wrote is there
-//!     let read_query = Query::raw_read_query("SELECT * FROM weather");
+//!     let read_query = ReadQuery::new("SELECT * FROM weather");
 //!
 //!     let read_result = client.query(read_query).await;
 //!     assert!(read_result.is_ok(), "Read result was not ok");

--- a/influxdb/tests/utilities.rs
+++ b/influxdb/tests/utilities.rs
@@ -1,5 +1,6 @@
-use futures::prelude::*;
+use futures_util::FutureExt;
 use influxdb::{Client, Error, ReadQuery};
+use std::future::Future;
 use std::panic::{AssertUnwindSafe, UnwindSafe};
 
 #[allow(dead_code)]


### PR DESCRIPTION
## Description

Replace `futures` dependency with `futures-util` (a subset of former crate that is sufficient for influxdb).

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy
  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [ ] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
