### PR TITLE
Fix clippy lint on missing #[must_use] attributes

### DIFF
--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -77,6 +77,7 @@ impl Client {
     ///
     /// let _client = Client::new("http://localhost:8086", "test");
     /// ```
+    #[must_use = "Creating a client is pointless unless you use it"]
     pub fn new<S1, S2>(url: S1, database: S2) -> Self
     where
         S1: Into<String>,
@@ -105,6 +106,7 @@ impl Client {
     ///
     /// let _client = Client::new("http://localhost:9086", "test").with_auth("admin", "password");
     /// ```
+    #[must_use = "Creating a client is pointless unless you use it"]
     pub fn with_auth<S1, S2>(mut self, username: S1, password: S2) -> Self
     where
         S1: Into<String>,
@@ -118,6 +120,7 @@ impl Client {
     }
 
     /// Replaces the HTTP Client
+    #[must_use = "Creating a client is pointless unless you use it"]
     pub fn with_http_client(mut self, http_client: HttpClient) -> Self {
         self.client = http_client;
         self

--- a/influxdb/src/query/read_query.rs
+++ b/influxdb/src/query/read_query.rs
@@ -12,6 +12,7 @@ pub struct ReadQuery {
 
 impl ReadQuery {
     /// Creates a new [`ReadQuery`]
+    #[must_use = "Creating a query is pointless unless you execute it"]
     pub fn new<S>(query: S) -> Self
     where
         S: Into<String>,
@@ -22,6 +23,7 @@ impl ReadQuery {
     }
 
     /// Adds a query to the [`ReadQuery`]
+    #[must_use = "Creating a query is pointless unless you execute it"]
     pub fn add_query<S>(mut self, query: S) -> Self
     where
         S: Into<String>,

--- a/influxdb/src/query/write_query.rs
+++ b/influxdb/src/query/write_query.rs
@@ -37,6 +37,7 @@ pub struct WriteQuery {
 
 impl WriteQuery {
     /// Creates a new [`WriteQuery`](crate::query::write_query::WriteQuery)
+    #[must_use = "Creating a query is pointless unless you execute it"]
     pub fn new<S>(timestamp: Timestamp, measurement: S) -> Self
     where
         S: Into<String>,
@@ -59,6 +60,7 @@ impl WriteQuery {
     ///
     /// Timestamp::Nanoseconds(0).into_query("measurement").add_field("field1", 5).build();
     /// ```
+    #[must_use = "Creating a query is pointless unless you execute it"]
     pub fn add_field<S, F>(mut self, field: S, value: F) -> Self
     where
         S: Into<String>,
@@ -83,6 +85,7 @@ impl WriteQuery {
     ///     .into_query("measurement")
     ///     .add_tag("field1", 5); // calling `.build()` now would result in a `Err(Error::InvalidQueryError)`
     /// ```
+    #[must_use = "Creating a query is pointless unless you execute it"]
     pub fn add_tag<S, I>(mut self, tag: S, value: I) -> Self
     where
         S: Into<String>,


### PR DESCRIPTION
## Description

Fix clippy lint on missing `#[must_use]` attributes

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy
  - [x] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [ ] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
