### PR TITLE
Disable chrono's default features

### DIFF
--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -13,7 +13,7 @@ include = ["src/**/*", "tests/**/*", "Cargo.toml", "LICENSE"]
 repository = "https://github.com/influxdb-rs/influxdb-rust"
 
 [dependencies]
-chrono = { version = "0.4.11", features = ["serde"] }
+chrono = { version = "0.4.11", features = ["serde"], default-features = false }
 futures-util = "0.3.17"
 http = "0.2.4"
 influxdb_derive = { version = "0.5.0", optional = true }


### PR DESCRIPTION
## Description

There is no need for time 0.1 compatibility (see #108)

### Checklist
- [ ] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy
  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [ ] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
