### PR TITLE
Updating README.md to reflect bulk write capability added in #87

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Pull requests are always welcome. See [Contributing](https://github.com/influxdb
 -   Reading and Writing to InfluxDB
 -   Optional Serde Support for Deserialization
 -   Running multiple queries in one request (e.g. `SELECT * FROM weather_berlin; SELECT * FROM weather_london`)
+-   Writing single or multiple measurements in one request (e.g. `WriteQuery` or `Vec<WriteQuery>` argument)
 -   Authenticated and Unauthenticated Connections
 -   `async`/`await` support
 -   `#[derive(InfluxDbWriteable)]` Derive Macro for Writing / Reading into Structs
@@ -76,14 +77,21 @@ async fn main() {
     }
 
     // Let's write some data into a measurement called `weather`
-    let weather_reading = WeatherReading {
-        time: Timestamp::Hours(1).into(),
-        humidity: 30,
-        wind_direction: String::from("north"),
-    };
+    let weather_readings = vec!(
+        WeatherReading {
+            time: Timestamp::Hours(1).into(),
+            humidity: 30,
+            wind_direction: String::from("north"),
+        }.into_query("weather"),
+        WeatherReading {
+            time: Timestamp::Hours(2).into(),
+            humidity: 40,
+            wind_direction: String::from("west"),
+        }.into_query("weather"),
+    );
 
     let write_result = client
-        .query(weather_reading.into_query("weather"))
+        .query(weather_readings)
         .await;
     assert!(write_result.is_ok(), "Write result was not okay");
 

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -8,6 +8,7 @@
 //! -   Reading and Writing to InfluxDB
 //! -   Optional Serde Support for Deserialization
 //! -   Running multiple queries in one request (e.g. `SELECT * FROM weather_berlin; SELECT * FROM weather_london`)
+//! -   Writing single or multiple measurements in one request (e.g. `WriteQuery` or `Vec<WriteQuery>` argument)
 //! -   Authenticated and Unauthenticated Connections
 //! -   `async`/`await` support
 //! -   `#[derive(InfluxDbWriteable)]` Derive Macro for Writing / Reading into Structs
@@ -44,14 +45,21 @@
 //!     }
 //!
 //!     // Let's write some data into a measurement called `weather`
-//!     let weather_reading = WeatherReading {
-//!         time: Timestamp::Hours(1).into(),
-//!         humidity: 30,
-//!         wind_direction: String::from("north"),
-//!     };
+//!     let weather_readings = vec!(
+//!         WeatherReading {
+//!             time: Timestamp::Hours(1).into(),
+//!             humidity: 30,
+//!             wind_direction: String::from("north"),
+//!         }.into_query("weather"),
+//!         WeatherReading {
+//!             time: Timestamp::Hours(2).into(),
+//!             humidity: 40,
+//!             wind_direction: String::from("west"),
+//!         }.into_query("weather"),
+//!     );
 //!
 //!     let write_result = client
-//!         .query(weather_reading.into_query("weather"))
+//!         .query(weather_readings)
 //!         .await;
 //!     assert!(write_result.is_ok(), "Write result was not okay");
 //!


### PR DESCRIPTION
## Description

PR #87 added the ability to use `Vec<WriteQuery>` to effect bulk writes. This PR updates README.md to reflect that capability including an updated example using bulk write.

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy
  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [x] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
