### PR TITLE
influxdb/src/query:  Send uints as unsigned integers on the line protocol (`u` suffix instead of `i`)

### DIFF
--- a/influxdb/src/query/line_proto_term.rs
+++ b/influxdb/src/query/line_proto_term.rs
@@ -43,7 +43,7 @@ impl LineProtoTerm<'_> {
             .to_string(),
             Float(v) => v.to_string(),
             SignedInteger(v) => format!("{}i", v),
-            UnsignedInteger(v) => format!("{}i", v),
+            UnsignedInteger(v) => format!("{}u", v),
             Text(v) => format!(r#""{}""#, Self::escape_any(v, &*QUOTES_SLASHES)),
         }
     }

--- a/influxdb/src/query/write_query.rs
+++ b/influxdb/src/query/write_query.rs
@@ -264,12 +264,13 @@ mod tests {
             .into_query("weather".to_string())
             .add_field("temperature", 82)
             .add_field("wind_strength", 3.7)
+            .add_field("temperature_unsigned", 82u64)
             .build();
 
         assert!(query.is_ok(), "Query was empty");
         assert_eq!(
             query.unwrap(),
-            "weather temperature=82i,wind_strength=3.7 11"
+            "weather temperature=82i,wind_strength=3.7,temperature_unsigned=82u 11"
         );
     }
 
@@ -282,7 +283,7 @@ mod tests {
             .build();
 
         assert!(query.is_ok(), "Query was empty");
-        assert_eq!(query.unwrap(), "weather temperature=82i 11");
+        assert_eq!(query.unwrap(), "weather temperature=82u 11");
     }
 
     #[test]


### PR DESCRIPTION
## Description
Currently, we serialize `u8`/`u16`/`u32`/`u64` fields as signed integers in the line protocol (e.g. `82i`).  This changes them to send as unsigned integers (e.g. `82u`)

It might make sense for this be opt-in behavior, or at the very least a breaking change as far as semver is concerned (e.g. v0.6.0); unsigned integer support wasn't merged into influxdb until 1.4.0, so users with sufficiently old versions of influxdb could have a bad experience.

Quick note - I did run clippy and it fails on a few things, but nothing I changed.  I can include fixes if desired, but I didn't want to tack on unrelated changes that might be considered out of scope - let me know!

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy
  - [x] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [x] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [x] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
