### PR TITLE
Fix clippy lints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                rust_release: ["1.53", stable, nightly]
+                rust_release: ["1.56", stable, nightly]
                 os: [ubuntu-latest, windows-latest, macOS-latest]
 
         steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
         name: README Format Check
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@nightly
             - run: bash ./auxiliary/update_cargo-readme.sh
             - run: bash ./auxiliary/check_readme_consistency.sh
@@ -20,12 +20,15 @@ jobs:
         name: Style Checks (stable/ubuntu-latest)
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@nightly
               with:
-                  components: "rustfmt,clippy"
+                  components: rustfmt
             - name: Check code formatting
               run: cargo fmt --all -- --check
+            - uses: dtolnay/rust-toolchain@1.63.0
+              with:
+                components: clippy
             - name: Check Clippy lints (reqwest)
               run: cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings
             - name: Check Clippy lints (surf)
@@ -40,7 +43,7 @@ jobs:
                 os: [ubuntu-latest, windows-latest, macOS-latest]
 
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@master
               with:
                   toolchain: ${{ matrix.rust_release }}
@@ -70,13 +73,13 @@ jobs:
                     INFLUXDB_USER_PASSWORD: password
 
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@stable
             - run: cargo test --manifest-path=./influxdb/Cargo.toml --no-default-features --features 'use-serde derive ${{ matrix.http-backend }}' --no-fail-fast
 
     coverage:
-        name: Code Coverage (stable/ubuntu-20.04)
-        runs-on: ubuntu-20.04
+        name: Code Coverage (stable/ubuntu-latest)
+        runs-on: ubuntu-latest
         services:
             influxdb:
                 image: influxdb:1.8
@@ -94,7 +97,7 @@ jobs:
                     INFLUXDB_USER_PASSWORD: password
 
         steps:
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@v3
           - uses: dtolnay/rust-toolchain@stable
 
           - name: Get Rust Version
@@ -103,9 +106,9 @@ jobs:
 
           - name: Get Tarpaulin Version
             id: tarpaulin-version
-            run: echo "::set-output name=VERSION::$(wget -qO- 'https://api.github.com/repos/xd009642/tarpaulin/releases/latest' | jq -r '.tag_name')"
+            run: echo "::set-output name=VERSION::$(wget -qO- 'https://crates.io/api/v1/crates/cargo-tarpaulin' | jq -r '.crate.max_stable_version')"
 
-          - uses: actions/cache@v2
+          - uses: actions/cache@v3
             with:
               path: |
                 ~/.cargo/bin/cargo-tarpaulin
@@ -133,7 +136,7 @@ jobs:
               RUST_BACKTRACE: 1
               RUST_LOG: info
 
-          - uses: actions/upload-artifact@v2
+          - uses: actions/upload-artifact@v3
             with:
               name: tarpaulin-report
               path: |
@@ -141,16 +144,16 @@ jobs:
                 tarpaulin-report.html
 
     pages:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         needs:
           - coverage
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         steps:
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@v3
             with:
               ref: gh-pages
 
-          - uses: actions/download-artifact@v2
+          - uses: actions/download-artifact@v3
             with:
               name: tarpaulin-report
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html">
-        <img src="https://img.shields.io/badge/rustc-1.53+-yellow.svg" alt='Minimum Rust Version' />
+    <a href="https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html">
+        <img src="https://img.shields.io/badge/rustc-1.56+-yellow.svg" alt='Minimum Rust Version' />
     </a>
 </p>
 

--- a/README.tpl
+++ b/README.tpl
@@ -25,8 +25,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html">
-        <img src="https://img.shields.io/badge/rustc-1.53+-yellow.svg" alt='Minimum Rust Version' />
+    <a href="https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html">
+        <img src="https://img.shields.io/badge/rustc-1.56+-yellow.svg" alt='Minimum Rust Version' />
     </a>
 </p>
 

--- a/influxdb/src/query/mod.rs
+++ b/influxdb/src/query/mod.rs
@@ -35,7 +35,7 @@ use consts::{MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MILLI, SECONDS_PER_M
 #[cfg(feature = "derive")]
 pub use influxdb_derive::InfluxDbWriteable;
 
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum Timestamp {
     Nanoseconds(u128),
     Microseconds(u128),
@@ -127,11 +127,11 @@ impl<Q: Query> Query for &Q {
 
 impl<Q: Query> Query for Box<Q> {
     fn build(&self) -> Result<ValidQuery, Error> {
-        Q::build(&*self)
+        Q::build(self)
     }
 
     fn get_type(&self) -> QueryType {
-        Q::get_type(&*self)
+        Q::get_type(self)
     }
 }
 
@@ -192,7 +192,7 @@ impl PartialEq<&str> for ValidQuery {
 }
 
 /// Internal Enum used to decide if a `POST` or `GET` request should be sent to InfluxDB. See [InfluxDB Docs](https://docs.influxdata.com/influxdb/v1.7/tools/api/#query-http-endpoint).
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum QueryType {
     ReadQuery,
     /// write query with precision


### PR DESCRIPTION
## Description

 - Fix clippy lints
 - Pin clippy version to 1.63.0 to avoid PRs failing with unrelated warnings
 - Update our GitHub actions and ensure we don't use prerelease versions of tarpaulin
 - Bump MSRV to 1.56 for dependencies

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy
  - [x] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [x] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [x] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
