### PR TITLE
Opt-in Line-Protocol for Compatibility Mode

### DIFF
--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -131,7 +131,7 @@ impl Client {
     /// Add authorization token to [`Client`](crate::Client)
     ///
     /// This is designed for influxdb 2.0's backward-compatible API which
-    /// requires authrozation by default. You can create such token from
+    /// requires authorization by default. You can create such token from
     /// console of influxdb 2.0 .
     pub fn with_token<S>(mut self, token: S) -> Self
     where

--- a/influxdb/src/query/line_proto_term.rs
+++ b/influxdb/src/query/line_proto_term.rs
@@ -25,12 +25,22 @@ impl LineProtoTerm<'_> {
         match self {
             Measurement(x) => Self::escape_any(x, &COMMAS_SPACES),
             TagKey(x) | FieldKey(x) => Self::escape_any(x, &COMMAS_SPACES_EQUALS),
-            FieldValue(x) => Self::escape_field_value(x),
+            FieldValue(x) => Self::escape_field_value(x, false),
             TagValue(x) => Self::escape_tag_value(x),
         }
     }
 
-    fn escape_field_value(v: &Type) -> String {
+    pub fn escape_v2(self) -> String {
+        use LineProtoTerm::*;
+        match self {
+            Measurement(x) => Self::escape_any(x, &COMMAS_SPACES),
+            TagKey(x) | FieldKey(x) => Self::escape_any(x, &COMMAS_SPACES_EQUALS),
+            FieldValue(x) => Self::escape_field_value(x, true),
+            TagValue(x) => Self::escape_tag_value(x),
+        }
+    }
+
+    fn escape_field_value(v: &Type, use_v2: bool) -> String {
         use Type::*;
         match v {
             Boolean(v) => {
@@ -43,7 +53,13 @@ impl LineProtoTerm<'_> {
             .to_string(),
             Float(v) => v.to_string(),
             SignedInteger(v) => format!("{}i", v),
-            UnsignedInteger(v) => format!("{}u", v),
+            UnsignedInteger(v) => {
+                if use_v2 {
+                    format!("{}u", v)
+                } else {
+                    format!("{}i", v)
+                }
+            },
             Text(v) => format!(r#""{}""#, Self::escape_any(v, &QUOTES_SLASHES)),
         }
     }
@@ -111,6 +127,12 @@ mod test {
 
         assert_eq!(FieldValue(&Type::SignedInteger(0)).escape(), r#"0i"#);
         assert_eq!(FieldValue(&Type::SignedInteger(83)).escape(), r#"83i"#);
+
+        assert_eq!(FieldValue(&Type::UnsignedInteger(0)).escape(), r#"0i"#);
+        assert_eq!(FieldValue(&Type::UnsignedInteger(83)).escape(), r#"83i"#);
+
+        assert_eq!(FieldValue(&Type::UnsignedInteger(0)).escape_v2(), r#"0u"#);
+        assert_eq!(FieldValue(&Type::UnsignedInteger(83)).escape_v2(), r#"83u"#);
 
         assert_eq!(FieldValue(&Type::Text("".into())).escape(), r#""""#);
         assert_eq!(FieldValue(&Type::Text("0".into())).escape(), r#""0""#);

--- a/influxdb/src/query/line_proto_term.rs
+++ b/influxdb/src/query/line_proto_term.rs
@@ -59,7 +59,7 @@ impl LineProtoTerm<'_> {
                 } else {
                     format!("{}i", v)
                 }
-            },
+            }
             Text(v) => format!(r#""{}""#, Self::escape_any(v, &QUOTES_SLASHES)),
         }
     }

--- a/influxdb/src/query/read_query.rs
+++ b/influxdb/src/query/read_query.rs
@@ -38,6 +38,10 @@ impl Query for ReadQuery {
         Ok(ValidQuery(self.queries.join(";")))
     }
 
+    fn build_with_opts(&self, _use_v2: bool) -> Result<ValidQuery, Error> {
+        Ok(ValidQuery(self.queries.join(";")))
+    }
+
     fn get_type(&self) -> QueryType {
         QueryType::ReadQuery
     }


### PR DESCRIPTION
## Description

Fixes #121 

#113 broke the Line Protocol for InfluxDB 1.X databases. This PR adds a opt-in mode for the line-protocol builder that uses the u suffix.

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy
  - [x] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [x] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [x] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
