### PR TITLE
Make Error comparable

### DIFF
--- a/influxdb/src/error.rs
+++ b/influxdb/src/error.rs
@@ -2,7 +2,7 @@
 
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Eq, PartialEq, Error)]
 pub enum Error {
     #[error("query is invalid: {error}")]
     /// Error happens when a query is invalid


### PR DESCRIPTION
## Description

This PR makes `Error` comparable. Useful in situations where a custom error enum is used.

This is useful in situation where, for example, a custom error enum is used:
```rust
#[derive(Eq, PartialEq, thiserror::Error)]
enum CustomError {
    #[error("error: {0}")]
    Normal(String),
    #[error("influx error: {0}")]
    Influx(#[source] influxdb::Error)
}

#[cfg(test)]
mod tests {
  use super::*;

  fn test() {
      let err = CustomError::Normal("err".to_string());
      let err1 = CustomError::Normal("err".to_string());
  
      // this assert only works when `PartialEq` is implemented/derived for `CustomError`
      assert_eq!(err, err1)
  }
}
```

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy (there are warnings, but the reasons for them are not my additions)
  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [x] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
