### PR TITLE
Fix json_query not sending token in request

### DIFF
--- a/influxdb/src/integrations/serde_integration/mod.rs
+++ b/influxdb/src/integrations/serde_integration/mod.rs
@@ -140,7 +140,11 @@ impl Client {
         let url = &format!("{}/query", &self.url);
         let mut parameters = self.parameters.as_ref().clone();
         parameters.insert("q", read_query);
-        let request_builder = self.client.get(url).query(&parameters);
+        let mut request_builder = self.client.get(url);
+        if let Some(ref token) = self.token {
+            request_builder = request_builder.header("Authorization", format!("Token {}", token))
+        }
+        let request_builder = request_builder.query(&parameters);
 
         #[cfg(feature = "surf")]
         let request_builder = request_builder.map_err(|err| Error::UrlConstructionError {


### PR DESCRIPTION
## Description

This PR fixes the issue that the `Client::json_query` function doesn't send the `Authorization` HTTP header (#126)

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy
  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [x] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
