### PR TITLE
Bump MSRV and Rust version used in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.63.0
+      - uses: dtolnay/rust-toolchain@1.72.0
         with:
           components: clippy
       - name: Check Clippy lints (reqwest)
@@ -54,7 +54,7 @@ jobs:
       matrix:
         rust:
           - name: MSRV
-            toolchain: "1.60"
+            toolchain: "1.63"
             nightly: false
           - name: Stable
             toolchain: stable
@@ -123,7 +123,9 @@ jobs:
           DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: admintoken
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{matrix.rust.toolchain}}
         id: rust-toolchain
       - uses: actions/cache@v3
         with:

--- a/README.j2
+++ b/README.j2
@@ -25,8 +25,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html">
-        <img src="https://img.shields.io/badge/rustc-1.60+-yellow.svg" alt='Minimum Rust Version: 1.60' />
+    <a href="https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html">
+        <img src="https://img.shields.io/badge/rustc-1.63+-yellow.svg" alt='Minimum Rust Version: 1.63' />
     </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html">
-        <img src="https://img.shields.io/badge/rustc-1.60+-yellow.svg" alt='Minimum Rust Version: 1.60' />
+    <a href="https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html">
+        <img src="https://img.shields.io/badge/rustc-1.63+-yellow.svg" alt='Minimum Rust Version: 1.63' />
     </a>
 </p>
 
@@ -167,7 +167,7 @@ To communicate with InfluxDB, you can choose the HTTP backend to be used configu
 @ 2020 Gero Gerke and [contributors].
 
  [contributors]: https://github.com/influxdb-rs/influxdb-rust/graphs/contributors
- [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEG-eS3ZnLalPKG8RSyE7OgxOuG5N_7FO9S6I9G5Bq0rFyX93cYXKEG5PjkhkfWGqnG0oaNZtY0rqCG3UxTXMZvJknG2Qnb8mp1lIsYWSBgmhpbmZsdXhkYmUwLjcuMA
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEG64av5CnNoNoGw8lPMr2b0MoG44uU0T70vGSG7osgcbjN7SoYXKEG5PjkhkfWGqnG0oaNZtY0rqCG3UxTXMZvJknG2Qnb8mp1lIsYWSBgmhpbmZsdXhkYmUwLjcuMA
  [__link0]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CONTRIBUTING.md
  [__link1]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CODE_OF_CONDUCT.md
  [__link10]: https://curl.se/libcurl/

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -50,7 +50,7 @@ impl<'a> Debug for RedactPassword<'a> {
                 _ => (*k, v.as_str()),
             })
             .collect::<BTreeMap<&'static str, &str>>();
-        f.debug_map().entries(entries.into_iter()).finish()
+        f.debug_map().entries(entries).finish()
     }
 }
 

--- a/influxdb/src/query/line_proto_term.rs
+++ b/influxdb/src/query/line_proto_term.rs
@@ -83,7 +83,7 @@ impl LineProtoTerm<'_> {
     }
 
     fn escape_any(s: &str, re: &Regex) -> String {
-        re.replace_all(s, r#"\$0"#).to_string()
+        re.replace_all(s, r"\$0").to_string()
     }
 }
 
@@ -101,11 +101,11 @@ mod test {
 
         assert_eq!(
             TagValue(&Type::Text("this is my special string".into())).escape(),
-            r#"this\ is\ my\ special\ string"#
+            r"this\ is\ my\ special\ string"
         );
         assert_eq!(
             TagValue(&Type::Text("a tag w=i th == tons of escapes".into())).escape(),
-            r#"a\ tag\ w\=i\ th\ \=\=\ tons\ of\ escapes"#
+            r"a\ tag\ w\=i\ th\ \=\=\ tons\ of\ escapes"
         );
         assert_eq!(
             TagValue(&Type::Text("no_escapes".into())).escape(),
@@ -113,11 +113,11 @@ mod test {
         );
         assert_eq!(
             TagValue(&Type::Text("some,commas,here".into())).escape(),
-            r#"some\,commas\,here"#
+            r"some\,commas\,here"
         );
 
         assert_eq!(Measurement(r#"wea", ther"#).escape(), r#"wea"\,\ ther"#);
-        assert_eq!(TagKey(r#"locat\ ,=ion"#).escape(), r#"locat\\ \,\=ion"#);
+        assert_eq!(TagKey(r"locat\ ,=ion").escape(), r"locat\\ \,\=ion");
 
         assert_eq!(FieldValue(&Type::Boolean(true)).escape(), r#"true"#);
         assert_eq!(FieldValue(&Type::Boolean(false)).escape(), r#"false"#);


### PR DESCRIPTION
## Description

Bump the MSRV to 1.63 since our (indirect) dependency `h2` requires it, and the Rust version used in CI for the clippy linter to 1.72.

### Checklist
- [ ] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy
  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [ ] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
- [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
