### PR TITLE
README: display clear errors in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,17 +93,18 @@ async fn main() {
         }.into_query("weather"),
     );
 
-    let write_result = client
-        .query(weather_readings)
-        .await;
-    assert!(write_result.is_ok(), "Write result was not okay");
+    if let Err(e) = client.query(weather_readings).await {
+        println!("Error writing result: {e}");
+        return;
+    }
 
     // Let's see if the data we wrote is there
     let read_query = ReadQuery::new("SELECT * FROM weather");
 
-    let read_result = client.query(read_query).await;
-    assert!(read_result.is_ok(), "Read result was not ok");
-    println!("{}", read_result.unwrap());
+    match client.query(read_query).await {
+        Ok(read_result) => println!("{}", read_result),
+        Err(e) => println!("Error reading result: {e}"),
+    }
 }
 ```
 
@@ -167,7 +168,7 @@ To communicate with InfluxDB, you can choose the HTTP backend to be used configu
 @ 2020 Gero Gerke and [contributors].
 
  [contributors]: https://github.com/influxdb-rs/influxdb-rust/graphs/contributors
- [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEG64av5CnNoNoGw8lPMr2b0MoG44uU0T70vGSG7osgcbjN7SoYXKEG1WEE9zY5dHaG_H-oHwVY518G_Hz3Ch_FlkHG6679elOy6u-YWSBgmhpbmZsdXhkYmUwLjcuMQ
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEG64av5CnNoNoGw8lPMr2b0MoG44uU0T70vGSG7osgcbjN7SoYXKEG_D2JHss1jsUG6eXkB7MmDoIG9miwB7MgvlwG_-cxCbQ3T7bYWSBgmhpbmZsdXhkYmUwLjcuMQ
  [__link0]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CONTRIBUTING.md
  [__link1]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CODE_OF_CONDUCT.md
  [__link10]: https://curl.se/libcurl/

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For an example with using Serde deserialization, please refer to [serde_integrat
 
 
 ```rust
-use influxdb::{Client, Query, Timestamp, ReadQuery};
+use influxdb::{Client, Timestamp, ReadQuery};
 use influxdb::InfluxDbWriteable;
 use chrono::{DateTime, Utc};
 
@@ -167,7 +167,7 @@ To communicate with InfluxDB, you can choose the HTTP backend to be used configu
 @ 2020 Gero Gerke and [contributors].
 
  [contributors]: https://github.com/influxdb-rs/influxdb-rust/graphs/contributors
- [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEG64av5CnNoNoGw8lPMr2b0MoG44uU0T70vGSG7osgcbjN7SoYXKEG8qCijK3OhAgG9r5dMb74ZyFGy-UgqMKZw5_G6wZmUfHdMJDYWSBgmhpbmZsdXhkYmUwLjcuMQ
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEG64av5CnNoNoGw8lPMr2b0MoG44uU0T70vGSG7osgcbjN7SoYXKEG1WEE9zY5dHaG_H-oHwVY518G_Hz3Ch_FlkHG6679elOy6u-YWSBgmhpbmZsdXhkYmUwLjcuMQ
  [__link0]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CONTRIBUTING.md
  [__link1]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CODE_OF_CONDUCT.md
  [__link10]: https://curl.se/libcurl/

--- a/README.md
+++ b/README.md
@@ -62,13 +62,12 @@ For an example with using Serde deserialization, please refer to [serde_integrat
 
 
 ```rust
-use influxdb::{Client, Timestamp, ReadQuery};
-use influxdb::InfluxDbWriteable;
 use chrono::{DateTime, Utc};
+use influxdb::{Client, Error, InfluxDbWriteable, ReadQuery, Timestamp};
 
 #[tokio::main]
 // or #[async_std::main] if you prefer
-async fn main() {
+async fn main() -> Result<(), Error> {
     // Connect to db `test` on `http://localhost:8086`
     let client = Client::new("http://localhost:8086", "test");
 
@@ -76,35 +75,34 @@ async fn main() {
     struct WeatherReading {
         time: DateTime<Utc>,
         humidity: i32,
-        #[influxdb(tag)] wind_direction: String,
+        #[influxdb(tag)]
+        wind_direction: String,
     }
 
     // Let's write some data into a measurement called `weather`
-    let weather_readings = vec!(
+    let weather_readings = vec![
         WeatherReading {
             time: Timestamp::Hours(1).into(),
             humidity: 30,
             wind_direction: String::from("north"),
-        }.into_query("weather"),
+        }
+        .into_query("weather"),
         WeatherReading {
             time: Timestamp::Hours(2).into(),
             humidity: 40,
             wind_direction: String::from("west"),
-        }.into_query("weather"),
-    );
+        }
+        .into_query("weather"),
+    ];
 
-    if let Err(e) = client.query(weather_readings).await {
-        println!("Error writing result: {e}");
-        return;
-    }
+    client.query(weather_readings).await?;
 
     // Let's see if the data we wrote is there
     let read_query = ReadQuery::new("SELECT * FROM weather");
 
-    match client.query(read_query).await {
-        Ok(read_result) => println!("{}", read_result),
-        Err(e) => println!("Error reading result: {e}"),
-    }
+    let read_result = client.query(read_query).await?;
+    println!("{}", read_result);
+    Ok(())
 }
 ```
 
@@ -168,7 +166,7 @@ To communicate with InfluxDB, you can choose the HTTP backend to be used configu
 @ 2020 Gero Gerke and [contributors].
 
  [contributors]: https://github.com/influxdb-rs/influxdb-rust/graphs/contributors
- [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEG64av5CnNoNoGw8lPMr2b0MoG44uU0T70vGSG7osgcbjN7SoYXKEG_D2JHss1jsUG6eXkB7MmDoIG9miwB7MgvlwG_-cxCbQ3T7bYWSBgmhpbmZsdXhkYmUwLjcuMQ
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEG64av5CnNoNoGw8lPMr2b0MoG44uU0T70vGSG7osgcbjN7SoYXKEGzTIyZ81-O7yGzBPOAorSf5GGwJWIVB6K85jG41Hl-f5lXJVYWSBgmhpbmZsdXhkYmUwLjcuMQ
  [__link0]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CONTRIBUTING.md
  [__link1]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CODE_OF_CONDUCT.md
  [__link10]: https://curl.se/libcurl/

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -56,17 +56,18 @@
 //!         }.into_query("weather"),
 //!     );
 //!
-//!     let write_result = client
-//!         .query(weather_readings)
-//!         .await;
-//!     assert!(write_result.is_ok(), "Write result was not okay");
+//!     if let Err(e) = client.query(weather_readings).await {
+//!         println!("Error writing result: {e}");
+//!         return;
+//!     }
 //!
 //!     // Let's see if the data we wrote is there
 //!     let read_query = ReadQuery::new("SELECT * FROM weather");
 //!
-//!     let read_result = client.query(read_query).await;
-//!     assert!(read_result.is_ok(), "Read result was not ok");
-//!     println!("{}", read_result.unwrap());
+//!     match client.query(read_query).await {
+//!         Ok(read_result) => println!("{}", read_result),
+//!         Err(e) => println!("Error reading result: {e}"),
+//!     }
 //! }
 //! ```
 //!

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -25,13 +25,12 @@
 //! For an example with using Serde deserialization, please refer to [serde_integration](crate::integrations::serde_integration)
 //!
 //! ```rust,no_run
-//! use influxdb::{Client, Timestamp, ReadQuery};
-//! use influxdb::InfluxDbWriteable;
 //! use chrono::{DateTime, Utc};
+//! use influxdb::{Client, Error, InfluxDbWriteable, ReadQuery, Timestamp};
 //!
 //! #[tokio::main]
 //! // or #[async_std::main] if you prefer
-//! async fn main() {
+//! async fn main() -> Result<(), Error> {
 //!     // Connect to db `test` on `http://localhost:8086`
 //!     let client = Client::new("http://localhost:8086", "test");
 //!
@@ -39,35 +38,34 @@
 //!     struct WeatherReading {
 //!         time: DateTime<Utc>,
 //!         humidity: i32,
-//!         #[influxdb(tag)] wind_direction: String,
+//!         #[influxdb(tag)]
+//!         wind_direction: String,
 //!     }
 //!
 //!     // Let's write some data into a measurement called `weather`
-//!     let weather_readings = vec!(
+//!     let weather_readings = vec![
 //!         WeatherReading {
 //!             time: Timestamp::Hours(1).into(),
 //!             humidity: 30,
 //!             wind_direction: String::from("north"),
-//!         }.into_query("weather"),
+//!         }
+//!         .into_query("weather"),
 //!         WeatherReading {
 //!             time: Timestamp::Hours(2).into(),
 //!             humidity: 40,
 //!             wind_direction: String::from("west"),
-//!         }.into_query("weather"),
-//!     );
+//!         }
+//!         .into_query("weather"),
+//!     ];
 //!
-//!     if let Err(e) = client.query(weather_readings).await {
-//!         println!("Error writing result: {e}");
-//!         return;
-//!     }
+//!     client.query(weather_readings).await?;
 //!
 //!     // Let's see if the data we wrote is there
 //!     let read_query = ReadQuery::new("SELECT * FROM weather");
 //!
-//!     match client.query(read_query).await {
-//!         Ok(read_result) => println!("{}", read_result),
-//!         Err(e) => println!("Error reading result: {e}"),
-//!     }
+//!     let read_result = client.query(read_query).await?;
+//!     println!("{}", read_result);
+//!     Ok(())
 //! }
 //! ```
 //!

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -25,7 +25,7 @@
 //! For an example with using Serde deserialization, please refer to [serde_integration](crate::integrations::serde_integration)
 //!
 //! ```rust,no_run
-//! use influxdb::{Client, Query, Timestamp, ReadQuery};
+//! use influxdb::{Client, Timestamp, ReadQuery};
 //! use influxdb::InfluxDbWriteable;
 //! use chrono::{DateTime, Utc};
 //!


### PR DESCRIPTION
## Description

Hi,

Building the example in the README raise the following warning:
```rust
warning: unused import: `Query`
 --> src/main.rs:1:24
  |
1 | use influxdb::{Client, Query, Timestamp, ReadQuery};
  |                        ^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```

And running it for me shows:
```
thread 'main' panicked at src/main.rs:35:5:
Write result was not okay
```

which is not super helpful.

With the proposed changes, I get:
```
Error writing result: authorization error. User not authorized
```
 which is more clear :)

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy
  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [x] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
