### PR TITLE
feat: added retention policy for v2 api

### DIFF
--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -141,6 +141,23 @@ impl Client {
         self
     }
 
+    /// Add a retention policy to [`Client`](crate::Client)
+    ///
+    /// This is designed for InfluxDB 2.x's backward-compatible API, which
+    /// maps databases and retention policies to buckets using the **database
+    /// and retention policy (DBRP) mapping service**.
+    /// See [InfluxDB Docs](https://docs.influxdata.com/influxdb/v2/reference/api/influxdb-1x/dbrp/) for more details.
+    #[must_use = "Creating a client is pointless unless you use it"]
+    pub fn with_retention_policy<S>(mut self, retention_policy: S) -> Self
+    where
+        S: Into<String>,
+    {
+        let mut with_retention_policy = self.parameters.as_ref().clone();
+        with_retention_policy.insert("rp", retention_policy.into());
+        self.parameters = Arc::new(with_retention_policy);
+        self
+    }
+
     /// Returns the name of the database the client is using
     pub fn database_name(&self) -> &str {
         // safe to unwrap: we always set the database name in `Self::new`


### PR DESCRIPTION
## Description

Added the ability to add a retention policy to the client parameters. Mainly for v2 compatibility, which uses the retention policy to map to bucket names https://docs.influxdata.com/influxdb/v2/reference/api/influxdb-1x/dbrp/

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy
  - [x] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [x] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [x] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment

Note: Method of chrono got deprecated which is causing some linting to fail, but that's unrelated to this PR. 
