### PR TITLE
Fix bug with conversion of Timestamp::Microseconds to chrono::Datetime

### DIFF
--- a/influxdb/src/query/consts.rs
+++ b/influxdb/src/query/consts.rs
@@ -3,6 +3,3 @@ pub const SECONDS_PER_MINUTE: u128 = 60;
 pub const MILLIS_PER_SECOND: u128 = 1000;
 pub const NANOS_PER_MILLI: u128 = 1_000_000;
 pub const NANOS_PER_MICRO: u128 = 1000;
-
-#[cfg(test)]
-pub const MICROS_PER_NANO: u128 = 1000;

--- a/influxdb/src/query/consts.rs
+++ b/influxdb/src/query/consts.rs
@@ -2,6 +2,7 @@ pub const MINUTES_PER_HOUR: u128 = 60;
 pub const SECONDS_PER_MINUTE: u128 = 60;
 pub const MILLIS_PER_SECOND: u128 = 1000;
 pub const NANOS_PER_MILLI: u128 = 1_000_000;
+pub const NANOS_PER_MICRO: u128 = 1000;
 
 #[cfg(test)]
 pub const MICROS_PER_NANO: u128 = 1000;

--- a/influxdb/src/query/mod.rs
+++ b/influxdb/src/query/mod.rs
@@ -30,7 +30,9 @@ pub mod write_query;
 use std::fmt;
 
 use crate::{Error, ReadQuery, WriteQuery};
-use consts::{MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MICRO, NANOS_PER_MILLI, SECONDS_PER_MINUTE};
+use consts::{
+    MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MICRO, NANOS_PER_MILLI, SECONDS_PER_MINUTE,
+};
 
 #[cfg(feature = "derive")]
 pub use influxdb_derive::InfluxDbWriteable;
@@ -230,8 +232,7 @@ pub enum QueryType {
 #[cfg(test)]
 mod tests {
     use super::consts::{
-        MICROS_PER_NANO, MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MICRO, NANOS_PER_MILLI,
-        SECONDS_PER_MINUTE,
+        MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MICRO, NANOS_PER_MILLI, SECONDS_PER_MINUTE,
     };
     use crate::query::{Timestamp, ValidQuery};
     use chrono::prelude::{DateTime, TimeZone, Utc};
@@ -302,14 +303,6 @@ mod tests {
     }
     #[test]
     fn test_chrono_datetime_from_timestamp_micros() {
-        let datetime_from_timestamp: DateTime<Utc> = Timestamp::Microseconds(1).into();
-        assert_eq!(
-            Utc.timestamp_nanos((1 / MICROS_PER_NANO).try_into().unwrap()),
-            datetime_from_timestamp
-        )
-    }
-    #[test]
-    fn test_chrono_datetime_from_timestamp_micros_second() {
         let datetime_from_timestamp: DateTime<Utc> = Timestamp::Microseconds(2).into();
         assert_eq!(
             Utc.timestamp_nanos((2 * NANOS_PER_MICRO).try_into().unwrap()),

--- a/influxdb/src/query/mod.rs
+++ b/influxdb/src/query/mod.rs
@@ -30,7 +30,7 @@ pub mod write_query;
 use std::fmt;
 
 use crate::{Error, ReadQuery, WriteQuery};
-use consts::{MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MILLI, SECONDS_PER_MINUTE};
+use consts::{MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MICRO, NANOS_PER_MILLI, SECONDS_PER_MINUTE};
 
 #[cfg(feature = "derive")]
 pub use influxdb_derive::InfluxDbWriteable;
@@ -76,8 +76,8 @@ impl From<Timestamp> for DateTime<Utc> {
                 Utc.timestamp_nanos(nanos.try_into().unwrap())
             }
             Timestamp::Nanoseconds(nanos) => Utc.timestamp_nanos(nanos.try_into().unwrap()),
-            Timestamp::Microseconds(mis) => {
-                let nanos = mis / 10000;
+            Timestamp::Microseconds(micros) => {
+                let nanos = micros * NANOS_PER_MICRO;
                 Utc.timestamp_nanos(nanos.try_into().unwrap())
             }
         }
@@ -230,7 +230,8 @@ pub enum QueryType {
 #[cfg(test)]
 mod tests {
     use super::consts::{
-        MICROS_PER_NANO, MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MILLI, SECONDS_PER_MINUTE,
+        MICROS_PER_NANO, MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MICRO, NANOS_PER_MILLI,
+        SECONDS_PER_MINUTE,
     };
     use crate::query::{Timestamp, ValidQuery};
     use chrono::prelude::{DateTime, TimeZone, Utc};
@@ -304,6 +305,14 @@ mod tests {
         let datetime_from_timestamp: DateTime<Utc> = Timestamp::Microseconds(1).into();
         assert_eq!(
             Utc.timestamp_nanos((1 / MICROS_PER_NANO).try_into().unwrap()),
+            datetime_from_timestamp
+        )
+    }
+    #[test]
+    fn test_chrono_datetime_from_timestamp_micros_second() {
+        let datetime_from_timestamp: DateTime<Utc> = Timestamp::Microseconds(2).into();
+        assert_eq!(
+            Utc.timestamp_nanos((2 * NANOS_PER_MICRO).try_into().unwrap()),
             datetime_from_timestamp
         )
     }


### PR DESCRIPTION
## Description

Fix bug with the conversion of Timestamp::Microseconds to chrono::Datetime 
Fix for issue #133 

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy
  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings`
- [ ] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
