### PR TITLE
Make `Error` enum `non_exhaustive`

### DIFF
--- a/influxdb/src/error.rs
+++ b/influxdb/src/error.rs
@@ -3,6 +3,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Eq, PartialEq, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("query is invalid: {error}")]
     /// Error happens when a query is invalid


### PR DESCRIPTION
This allows us to introduce future variants of the error enum without making braking changes.

