### PR TITLE
Remove `lazy_static` dependency

### DIFF
--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -17,8 +17,7 @@ chrono = { version = "0.4.23", features = ["serde"], default-features = false }
 futures-util = "0.3.17"
 http = "0.2.4"
 influxdb_derive = { version = "0.5.1", optional = true }
-lazy_static = "1.4.0"
-regex = "1.3.5"
+lazy-regex = "3.1"
 reqwest = { version = "0.11.4", default-features = false, optional = true }
 surf = { version = "2.2.0", default-features = false, optional = true }
 serde = { version = "1.0.186", optional = true }

--- a/influxdb/src/query/line_proto_term.rs
+++ b/influxdb/src/query/line_proto_term.rs
@@ -1,15 +1,12 @@
 /// InfluxDB Line Protocol escaping helper module.
 /// https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/
 use crate::Type;
-use lazy_static::lazy_static;
-use regex::Regex;
+use lazy_regex::{lazy_regex, Lazy, Regex};
 
-lazy_static! {
-    pub static ref COMMAS_SPACES: Regex = Regex::new("[, ]").unwrap();
-    pub static ref COMMAS_SPACES_EQUALS: Regex = Regex::new("[, =]").unwrap();
-    pub static ref QUOTES_SLASHES: Regex = Regex::new(r#"["\\]"#).unwrap();
-    pub static ref SLASHES: Regex = Regex::new(r#"(\\|,| |=|")"#).unwrap();
-}
+pub static COMMAS_SPACES: Lazy<Regex> = lazy_regex!("[, ]");
+pub static COMMAS_SPACES_EQUALS: Lazy<Regex> = lazy_regex!("[, =]");
+pub static QUOTES_SLASHES: Lazy<Regex> = lazy_regex!(r#"["\\]"#);
+pub static SLASHES: Lazy<Regex> = lazy_regex!(r#"(\\|,| |=|")"#);
 
 pub enum LineProtoTerm<'a> {
     Measurement(&'a str), // escape commas, spaces


### PR DESCRIPTION
Instead, we now use `lazy-regex`, which uses `once_cell` under the hood, which might eventually become part of std.
