### PR TITLE
Better Errors

### DIFF
--- a/docker-compose.integrationtest.yaml
+++ b/docker-compose.integrationtest.yaml
@@ -1,0 +1,27 @@
+version: '3'
+services:
+  influxdb:
+      image: influxdb:1.8
+      ports:
+        - 8086:8086
+  authed_influxdb:
+    image: influxdb:1.8
+    ports:
+      - 9086:8086
+    environment:
+      INFLUXDB_HTTP_AUTH_ENABLED: true
+      INFLUXDB_ADMIN_USER: admin
+      INFLUXDB_ADMIN_PASSWORD: password
+      INFLUXDB_USER: nopriv_user
+      INFLUXDB_USER_PASSWORD: password
+  influxdbv2:
+    image: influxdb:2.6
+    ports:
+      - 2086:8086
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: admin
+      DOCKER_INFLUXDB_INIT_PASSWORD: password
+      DOCKER_INFLUXDB_INIT_ORG: testing
+      DOCKER_INFLUXDB_INIT_BUCKET: mydb
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: admintoken

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -301,7 +301,11 @@ impl Client {
 pub(crate) fn check_status(res: &HttpResponse) -> Result<(), Error> {
     let status = res.status();
     if !status.is_success() {
-        return Err(Error::ApiError(status));
+        #[cfg(feature = "surf")]
+        let err = Err(Error::ApiError(status.into()));
+        #[cfg(feature = "reqwest")]
+        let err = Err(Error::ApiError(status));
+        return err;
     }
     Ok(())
 }

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -301,13 +301,10 @@ impl Client {
 
 pub(crate) fn check_status(res: &HttpResponse) -> Result<(), Error> {
     let status = res.status();
-    if status == StatusCode::UNAUTHORIZED.as_u16() {
-        Err(Error::AuthorizationError)
-    } else if status == StatusCode::FORBIDDEN.as_u16() {
-        Err(Error::AuthenticationError)
-    } else {
-        Ok(())
+    if !status.is_success() {
+        return Err(Error::ApiError(status));
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -16,7 +16,6 @@
 //! ```
 
 use futures_util::TryFutureExt;
-use http::StatusCode;
 #[cfg(feature = "reqwest")]
 use reqwest::{Client as HttpClient, RequestBuilder, Response as HttpResponse};
 use std::collections::{BTreeMap, HashMap};

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -281,7 +281,7 @@ impl Client {
         })?;
 
         // todo: improve error parsing without serde
-        if s.contains("\"error\"") {
+        if s.contains("\"error\"") || s.contains("\"Error\"") {
             return Err(Error::DatabaseError {
                 error: format!("influxdb error: \"{}\"", s),
             });

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -301,10 +301,7 @@ impl Client {
 pub(crate) fn check_status(res: &HttpResponse) -> Result<(), Error> {
     let status = res.status();
     if !status.is_success() {
-        #[cfg(feature = "surf")]
-        let err = Err(Error::ApiError(status.into()));
-        #[cfg(feature = "reqwest")]
-        let err = Err(Error::ApiError(status));
+        let err = Err(Error::ApiError(status.as_u16()));
         return err;
     }
     Ok(())

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -301,10 +301,7 @@ impl Client {
 pub(crate) fn check_status(res: &HttpResponse) -> Result<(), Error> {
     let status = res.status();
     if !status.is_success() {
-        #[cfg(feature = "surf")]
         return Err(Error::ApiError(status.into()));
-        #[cfg(feature = "reqwest")]
-        return Err(Error::ApiError(status));
     }
     Ok(())
 }

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -301,8 +301,10 @@ impl Client {
 pub(crate) fn check_status(res: &HttpResponse) -> Result<(), Error> {
     let status = res.status();
     if !status.is_success() {
-        let err = Err(Error::ApiError(status.as_u16()));
-        return err;
+        #[cfg(feature = "surf")]
+        return Err(Error::ApiError(status.into()));
+        #[cfg(feature = "reqwest")]
+        return Err(Error::ApiError(status));
     }
     Ok(())
 }

--- a/influxdb/src/error.rs
+++ b/influxdb/src/error.rs
@@ -1,6 +1,5 @@
 //! Errors that might happen in the crate
 
-use http::StatusCode;
 use thiserror::Error;
 
 #[derive(Debug, Eq, PartialEq, Error)]
@@ -36,7 +35,7 @@ pub enum Error {
 
     #[error("API error with a status code: {0}")]
     /// Error happens when API returns non 2xx status code.
-    ApiError(StatusCode),
+    ApiError(u16),
 
     #[error("connection error: {error}")]
     /// Error happens when HTTP request fails

--- a/influxdb/src/error.rs
+++ b/influxdb/src/error.rs
@@ -1,5 +1,6 @@
 //! Errors that might happen in the crate
 
+use http::StatusCode;
 use thiserror::Error;
 
 #[derive(Debug, Eq, PartialEq, Error)]
@@ -32,6 +33,10 @@ pub enum Error {
     #[error("authorization error. User not authorized")]
     /// Error happens when the supplied user is not authorized. `HTTP 403 Forbidden`
     AuthorizationError,
+
+    #[error("API error with a status code: {0}")]
+    /// Error happens when API returns non 2xx status code.
+    ApiError(StatusCode),
 
     #[error("connection error: {error}")]
     /// Error happens when HTTP request fails

--- a/influxdb/src/error.rs
+++ b/influxdb/src/error.rs
@@ -25,14 +25,6 @@ pub enum Error {
     /// Error which has happened inside InfluxDB
     DatabaseError { error: String },
 
-    #[error("authentication error. No or incorrect credentials")]
-    /// Error happens when no or incorrect credentials are used. `HTTP 401 Unauthorized`
-    AuthenticationError,
-
-    #[error("authorization error. User not authorized")]
-    /// Error happens when the supplied user is not authorized. `HTTP 403 Forbidden`
-    AuthorizationError,
-
     #[error("API error with a status code: {0}")]
     /// Error happens when API returns non 2xx status code.
     ApiError(u16),

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -140,7 +140,14 @@ async fn test_wrong_authed_write_and_read() {
             let write_result = client.query(write_query).await;
             assert_result_err(&write_result);
             match write_result {
-                Err(Error::AuthorizationError) => {}
+                Err(Error::ApiError(code)) => {
+                    if code != 403 {
+                        panic!(
+                            "Should be an ApiError(403), but code received was: {}",
+                            code
+                        );
+                    }
+                }
                 _ => panic!(
                     "Should be an AuthorizationError: {}",
                     write_result.unwrap_err()
@@ -151,7 +158,14 @@ async fn test_wrong_authed_write_and_read() {
             let read_result = client.query(read_query).await;
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::AuthorizationError) => {}
+                Err(Error::ApiError(code)) => {
+                    if code != 403 {
+                        panic!(
+                            "Should be an ApiError(403), but code received was: {}",
+                            code
+                        );
+                    }
+                }
                 _ => panic!(
                     "Should be an AuthorizationError: {}",
                     read_result.unwrap_err()
@@ -164,7 +178,14 @@ async fn test_wrong_authed_write_and_read() {
             let read_result = client.query(read_query).await;
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::AuthenticationError) => {}
+                Err(Error::ApiError(code)) => {
+                    if code != 401 {
+                        panic!(
+                            "Should be an ApiError(401), but code received was: {}",
+                            code
+                        );
+                    }
+                }
                 _ => panic!(
                     "Should be an AuthenticationError: {}",
                     read_result.unwrap_err()
@@ -208,7 +229,14 @@ async fn test_non_authed_write_and_read() {
             let write_result = non_authed_client.query(write_query).await;
             assert_result_err(&write_result);
             match write_result {
-                Err(Error::AuthorizationError) => {}
+                Err(Error::ApiError(code)) => {
+                    if code != 403 {
+                        panic!(
+                            "Should be an ApiError(403), but code received was: {}",
+                            code
+                        );
+                    }
+                }
                 _ => panic!(
                     "Should be an AuthorizationError: {}",
                     write_result.unwrap_err()
@@ -220,7 +248,14 @@ async fn test_non_authed_write_and_read() {
 
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::AuthorizationError) => {}
+                Err(Error::ApiError(code)) => {
+                    if code != 403 {
+                        panic!(
+                            "Should be an ApiError(403), but code received was: {}",
+                            code
+                        );
+                    }
+                }
                 _ => panic!(
                     "Should be an AuthorizationError: {}",
                     read_result.unwrap_err()
@@ -297,7 +332,14 @@ async fn test_json_non_authed_read() {
             let read_result = non_authed_client.json_query(read_query).await;
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::AuthorizationError) => {}
+                Err(Error::ApiError(code)) => {
+                    if code != 403 {
+                        panic!(
+                            "Should be an ApiError(403), but code received was: {}",
+                            code
+                        );
+                    }
+                }
                 _ => panic!(
                     "Should be a AuthorizationError: {}",
                     read_result.unwrap_err()

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -120,6 +120,8 @@ async fn test_authed_write_and_read() {
 #[async_std::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_wrong_authed_write_and_read() {
+    use http::StatusCode;
+
     const TEST_NAME: &str = "test_wrong_authed_write_and_read";
 
     run_test(
@@ -140,16 +142,9 @@ async fn test_wrong_authed_write_and_read() {
             let write_result = client.query(write_query).await;
             assert_result_err(&write_result);
             match write_result {
-                Err(Error::ApiError(code)) => {
-                    if code != 403 {
-                        panic!(
-                            "Should be an ApiError(403), but code received was: {}",
-                            code
-                        );
-                    }
-                }
+                Err(Error::ApiError(code)) if code == StatusCode::UNAUTHORIZED.as_u16() => {}
                 _ => panic!(
-                    "Should be an AuthorizationError: {}",
+                    "Should be an ApiError(UNAUTHORIZED): {}",
                     write_result.unwrap_err()
                 ),
             }
@@ -158,16 +153,9 @@ async fn test_wrong_authed_write_and_read() {
             let read_result = client.query(read_query).await;
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::ApiError(code)) => {
-                    if code != 403 {
-                        panic!(
-                            "Should be an ApiError(403), but code received was: {}",
-                            code
-                        );
-                    }
-                }
+                Err(Error::ApiError(code)) if code == StatusCode::UNAUTHORIZED.as_u16() => {}
                 _ => panic!(
-                    "Should be an AuthorizationError: {}",
+                    "Should be an ApiError(UNAUTHORIZED): {}",
                     read_result.unwrap_err()
                 ),
             }
@@ -178,16 +166,9 @@ async fn test_wrong_authed_write_and_read() {
             let read_result = client.query(read_query).await;
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::ApiError(code)) => {
-                    if code != 401 {
-                        panic!(
-                            "Should be an ApiError(401), but code received was: {}",
-                            code
-                        );
-                    }
-                }
+                Err(Error::ApiError(code)) if code == StatusCode::FORBIDDEN.as_u16() => {}
                 _ => panic!(
-                    "Should be an AuthenticationError: {}",
+                    "Should be an ApiError(UNAUTHENTICATED): {}",
                     read_result.unwrap_err()
                 ),
             }
@@ -211,6 +192,8 @@ async fn test_wrong_authed_write_and_read() {
 #[async_std::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_non_authed_write_and_read() {
+    use http::StatusCode;
+
     const TEST_NAME: &str = "test_non_authed_write_and_read";
 
     run_test(
@@ -229,16 +212,9 @@ async fn test_non_authed_write_and_read() {
             let write_result = non_authed_client.query(write_query).await;
             assert_result_err(&write_result);
             match write_result {
-                Err(Error::ApiError(code)) => {
-                    if code != 403 {
-                        panic!(
-                            "Should be an ApiError(403), but code received was: {}",
-                            code
-                        );
-                    }
-                }
+                Err(Error::ApiError(code)) if code == StatusCode::UNAUTHORIZED.as_u16() => {}
                 _ => panic!(
-                    "Should be an AuthorizationError: {}",
+                    "Should be an ApiError(UNAUTHORIZED): {}",
                     write_result.unwrap_err()
                 ),
             }
@@ -248,16 +224,9 @@ async fn test_non_authed_write_and_read() {
 
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::ApiError(code)) => {
-                    if code != 403 {
-                        panic!(
-                            "Should be an ApiError(403), but code received was: {}",
-                            code
-                        );
-                    }
-                }
+                Err(Error::ApiError(code)) if code == StatusCode::UNAUTHORIZED.as_u16() => {}
                 _ => panic!(
-                    "Should be an AuthorizationError: {}",
+                    "Should be an ApiError(UNAUTHORIZED): {}",
                     read_result.unwrap_err()
                 ),
             }
@@ -315,6 +284,8 @@ async fn test_write_and_read_field() {
 #[cfg(feature = "serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_non_authed_read() {
+    use http::StatusCode;
+
     const TEST_NAME: &str = "test_json_non_authed_read";
 
     run_test(
@@ -332,16 +303,9 @@ async fn test_json_non_authed_read() {
             let read_result = non_authed_client.json_query(read_query).await;
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::ApiError(code)) => {
-                    if code != 403 {
-                        panic!(
-                            "Should be an ApiError(403), but code received was: {}",
-                            code
-                        );
-                    }
-                }
+                Err(Error::ApiError(code)) if code == StatusCode::UNAUTHORIZED.as_u16() => {}
                 _ => panic!(
-                    "Should be a AuthorizationError: {}",
+                    "Should be an ApiError(UNAUTHORIZED): {}",
                     read_result.unwrap_err()
                 ),
             }

--- a/influxdb/tests/integration_tests_v2.rs
+++ b/influxdb/tests/integration_tests_v2.rs
@@ -48,6 +48,8 @@ async fn test_authed_write_and_read() {
 #[async_std::test]
 #[cfg(not(tarpaulin))]
 async fn test_wrong_authed_write_and_read() {
+    use http::StatusCode;
+
     run_test(
         || async move {
             let client = Client::new("http://127.0.0.1:2086", "mydb").with_token("falsetoken");
@@ -57,16 +59,9 @@ async fn test_wrong_authed_write_and_read() {
             let write_result = client.query(&write_query).await;
             assert_result_err(&write_result);
             match write_result {
-                Err(Error::ApiError(code)) => {
-                    if code != 403 {
-                        panic!(
-                            "Should be an ApiError(403), but code received was: {}",
-                            code
-                        );
-                    }
-                }
+                Err(Error::ApiError(code)) if code == StatusCode::UNAUTHORIZED.as_u16() => {}
                 _ => panic!(
-                    "Should be an AuthorizationError: {}",
+                    "Should be an ApiError(UNAUTHORIZED): {}",
                     write_result.unwrap_err()
                 ),
             }
@@ -75,16 +70,9 @@ async fn test_wrong_authed_write_and_read() {
             let read_result = client.query(&read_query).await;
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::ApiError(code)) => {
-                    if code != 403 {
-                        panic!(
-                            "Should be an ApiError(403), but code received was: {}",
-                            code
-                        );
-                    }
-                }
+                Err(Error::ApiError(code)) if code == StatusCode::UNAUTHORIZED.as_u16() => {}
                 _ => panic!(
-                    "Should be an AuthorizationError: {}",
+                    "Should be an ApiError(UNAUTHORIZED): {}",
                     read_result.unwrap_err()
                 ),
             }
@@ -100,6 +88,8 @@ async fn test_wrong_authed_write_and_read() {
 #[async_std::test]
 #[cfg(not(tarpaulin))]
 async fn test_non_authed_write_and_read() {
+    use http::StatusCode;
+
     run_test(
         || async move {
             let non_authed_client = Client::new("http://127.0.0.1:2086", "mydb");
@@ -109,16 +99,9 @@ async fn test_non_authed_write_and_read() {
             let write_result = non_authed_client.query(&write_query).await;
             assert_result_err(&write_result);
             match write_result {
-                Err(Error::ApiError(code)) => {
-                    if code != 403 {
-                        panic!(
-                            "Should be an ApiError(403), but code received was: {}",
-                            code
-                        );
-                    }
-                }
+                Err(Error::ApiError(code)) if code == StatusCode::UNAUTHORIZED.as_u16() => {}
                 _ => panic!(
-                    "Should be an AuthorizationError: {}",
+                    "Should be an ApiError(UNAUTHORIZED): {}",
                     write_result.unwrap_err()
                 ),
             }
@@ -127,16 +110,9 @@ async fn test_non_authed_write_and_read() {
             let read_result = non_authed_client.query(&read_query).await;
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::ApiError(code)) => {
-                    if code != 403 {
-                        panic!(
-                            "Should be an ApiError(403), but code received was: {}",
-                            code
-                        );
-                    }
-                }
+                Err(Error::ApiError(code)) if code == StatusCode::UNAUTHORIZED.as_u16() => {}
                 _ => panic!(
-                    "Should be an AuthorizationError: {}",
+                    "Should be an ApiError(UNAUTHORIZED): {}",
                     read_result.unwrap_err()
                 ),
             }

--- a/influxdb/tests/integration_tests_v2.rs
+++ b/influxdb/tests/integration_tests_v2.rs
@@ -33,7 +33,7 @@ async fn test_authed_write_and_read() {
         },
         || async move {
             let client = Client::new("http://127.0.0.1:2086", "mydb").with_token("admintoken");
-            let read_query = ReadQuery::new("DELETE MEASUREMENT weather");
+            let read_query = ReadQuery::new("DROP MEASUREMENT \"weather\"");
             let read_result = client.query(read_query).await;
             assert_result_ok(&read_result);
             assert!(!read_result.unwrap().contains("error"), "Teardown failed");

--- a/influxdb/tests/integration_tests_v2.rs
+++ b/influxdb/tests/integration_tests_v2.rs
@@ -57,7 +57,14 @@ async fn test_wrong_authed_write_and_read() {
             let write_result = client.query(&write_query).await;
             assert_result_err(&write_result);
             match write_result {
-                Err(Error::AuthorizationError) => {}
+                Err(Error::ApiError(code)) => {
+                    if code != 403 {
+                        panic!(
+                            "Should be an ApiError(403), but code received was: {}",
+                            code
+                        );
+                    }
+                }
                 _ => panic!(
                     "Should be an AuthorizationError: {}",
                     write_result.unwrap_err()
@@ -68,7 +75,14 @@ async fn test_wrong_authed_write_and_read() {
             let read_result = client.query(&read_query).await;
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::AuthorizationError) => {}
+                Err(Error::ApiError(code)) => {
+                    if code != 403 {
+                        panic!(
+                            "Should be an ApiError(403), but code received was: {}",
+                            code
+                        );
+                    }
+                }
                 _ => panic!(
                     "Should be an AuthorizationError: {}",
                     read_result.unwrap_err()
@@ -95,7 +109,14 @@ async fn test_non_authed_write_and_read() {
             let write_result = non_authed_client.query(&write_query).await;
             assert_result_err(&write_result);
             match write_result {
-                Err(Error::AuthorizationError) => {}
+                Err(Error::ApiError(code)) => {
+                    if code != 403 {
+                        panic!(
+                            "Should be an ApiError(403), but code received was: {}",
+                            code
+                        );
+                    }
+                }
                 _ => panic!(
                     "Should be an AuthorizationError: {}",
                     write_result.unwrap_err()
@@ -106,7 +127,14 @@ async fn test_non_authed_write_and_read() {
             let read_result = non_authed_client.query(&read_query).await;
             assert_result_err(&read_result);
             match read_result {
-                Err(Error::AuthorizationError) => {}
+                Err(Error::ApiError(code)) => {
+                    if code != 403 {
+                        panic!(
+                            "Should be an ApiError(403), but code received was: {}",
+                            code
+                        );
+                    }
+                }
                 _ => panic!(
                     "Should be an AuthorizationError: {}",
                     read_result.unwrap_err()


### PR DESCRIPTION
## Description

Slightly reworked PR #137.

Still not ready as further discussion has to be done before I can finalize it.

Improved error handling and exhaustive handling of all the possible error codes. In original implementation only two variants of enum were handled in conditional manner (which is not robust in this case). The proposed usage of pattern matching via "match" case is a better way of handling errors. I have proposed a new enum variant for an Error that returns the standardized error code instead.

TODO:

1. Decide on typing.
2. Integrate agreed method to tests.

FIXME:

Currently, as we are using both surf and reqwest, the StatusCode is a problem as both crates have their distinct types with different methods (one of the ideas was to use .as_u16() and store it as u16 inside the error enum, however, surf does not have such method implemented).
I tried a few things but seemed to be unable to come up with a unified solution that would pass all the GH workflows.

What I propose?

I propose making our own StatusCode with trait impl for all of the above types of StatusCode. This way, we will be able to have a cleaner code with just a single .into(), instead of adding bunch of feature gated imports etc.

Plz, let me know what you think.

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy
  - [x] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features serde,derive,reqwest-client-rustls -- -D warnings`
  - [x] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features serde,derive,hyper-client -- -D warnings`
- [x] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
