### PR TITLE
Refactor expect to Result<> mapping

### DIFF
--- a/influxdb_derive/src/writeable.rs
+++ b/influxdb_derive/src/writeable.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::convert::TryFrom;
+use syn::spanned::Spanned;
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
@@ -51,7 +52,16 @@ impl TryFrom<Field> for WriteableField {
     type Error = syn::Error;
 
     fn try_from(field: Field) -> syn::Result<WriteableField> {
-        let ident = field.ident.expect("fields without ident are not supported");
+        let ident = match field.ident {
+            Some(i) => i,
+            None => {
+                return Err(syn::Error::new_spanned(
+                    &field,
+                    "fields without ident are not supported",
+                ))
+            }
+        };
+
         let mut is_tag = false;
         let mut is_ignore = false;
 


### PR DESCRIPTION
## Description

Refactors a possible panic to use graceful error handling

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy
  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features serde,derive,reqwest-client-rustls -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features serde,derive,hyper-client -- -D warnings`
- [x] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
