### PR TITLE
CI: Use cargo 1.84 feature to check MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,6 +67,9 @@ jobs:
       fail-fast: false
       matrix:
         rust:
+          - name: MSRV
+            toolchain: stable
+            nightly: false
           - name: Stable
             toolchain: stable
             nightly: false
@@ -79,19 +82,34 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v4
+      # on non-msrv runs, just download rust
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust.toolchain}}
         id: rust-toolchain
+        if: matrix.rust.name != 'MSRV'
+      # on msrv runs, use stable to generate Cargo.lock then downgrade
+      - uses: dtolnay/rust-toolchain@stable
+        if: matrix.rust.name == 'MSRV'
+      - run: cargo --config 'resolver.incompatible-rust-versions="fallback"' update
+      - run: echo "rust-version=$(tomlq -r '.workspace.package."rust-version"' Cargo.toml)" >>$GITHUB_OUTPUT
+        id: msrv
+        if: matrix.rust.name == 'MSRV'
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{steps.msrv.outputs.rust-version}}
+        id: rust-toolchain
+        if: matrix.rust.name == 'MSRV'
+      # the rest is independent of whether msrv is used
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/git
             ~/.cargo/registry
             target
-          key: "${{matrix.rust.toolchain}} on ${{runner.os}} Rust ${{steps.rust-toolchain.outputs.cachekey}}"
-      - run: cargo test --lib
-      - run: cargo test --doc
+          key: "${{runner.os}} Rust ${{steps.rust-toolchain.outputs.cachekey}}"
+      - run: cargo test --lib --locked
+      - run: cargo test --doc --locked
 
   # this tests that all integration tests are successful
   integration_tests:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,13 @@
 [workspace]
 members = ["influxdb", "influxdb_derive", "benches"]
 
+[workspace.package]
+authors = ["Gero Gerke <11deutron11@gmail.com>", "Dominic <git@msrd0.de>"]
+edition = "2018"
+rust-version = "1.65"
+license = "MIT"
+repository = "https://github.com/influxdb-rs/influxdb-rust"
+
 [patch.crates-io]
 influxdb = { path = "./influxdb" }
 influxdb_derive = { path = "./influxdb_derive" }

--- a/README.j2
+++ b/README.j2
@@ -25,8 +25,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2022/11/03/Rust-1.67.0.html">
-        <img src="https://img.shields.io/badge/rustc-1.67+-yellow.svg" alt='Minimum Rust Version: 1.67' />
+    <a href="https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html">
+        <img src="https://img.shields.io/badge/rustc-1.65+-yellow.svg" alt='Minimum Rust Version: 1.65' />
     </a>
 </p>
 

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -3,15 +3,15 @@
 [package]
 name = "influxdb"
 version = "0.7.2"
-authors = ["Gero Gerke <11deutron11@gmail.com>"]
-edition = "2018"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "InfluxDB Driver for Rust"
 keywords = ["influxdb", "database", "influx"]
-license = "MIT"
+license.workspace = true
 readme = "README.md"
 include = ["src/**/*", "tests/**/*", "Cargo.toml", "LICENSE"]
-repository = "https://github.com/influxdb-rs/influxdb-rust"
-rust-version = "1.70"
+repository.workspace = true
 
 [dependencies]
 chrono = { version = "0.4.23", features = ["serde"], default-features = false }

--- a/influxdb_derive/Cargo.toml
+++ b/influxdb_derive/Cargo.toml
@@ -3,15 +3,15 @@
 [package]
 name = "influxdb_derive"
 version = "0.5.1"
-authors = ["Gero Gerke <11deutron11@gmail.com>"]
-edition = "2018"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Private implementation detail of the influxdb crate"
 keywords = ["influxdb", "database", "influx", "derive"]
-license = "MIT"
+license.workspace = true
 readme = "README.md"
 include = ["src/**/*", "tests/**/*", "Cargo.toml", "LICENSE"]
-repository = "https://github.com/influxdb-rs/influxdb-rust"
-rust-version = "1.70"
+repository.workspace = true
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html#cargo-considers-rust-versions-for-dependency-version-selection
