### PR TITLE
Renameable time field

### DIFF
--- a/influxdb/src/query/write_query.rs
+++ b/influxdb/src/query/write_query.rs
@@ -167,6 +167,13 @@ impl<Tz: chrono::TimeZone> From<chrono::DateTime<Tz>> for Type {
     }
 }
 
+#[cfg(feature = "time")]
+impl From<time::UtcDateTime> for Type {
+    fn from(dt: time::UtcDateTime) -> Self {
+        Type::SignedInteger(dt.unix_timestamp_nanos().try_into().unwrap_or(0))
+    }
+}
+
 impl<T> From<&T> for Type
 where
     T: Copy + Into<Type>,

--- a/influxdb/src/query/write_query.rs
+++ b/influxdb/src/query/write_query.rs
@@ -5,6 +5,7 @@
 use crate::query::line_proto_term::LineProtoTerm;
 use crate::query::{QueryType, ValidQuery};
 use crate::{Error, Query, Timestamp};
+use chrono::{DateTime, TimeZone};
 use std::fmt::{Display, Formatter};
 
 pub trait WriteType {
@@ -152,6 +153,20 @@ impl From<&str> for Type {
         Type::Text(b.into())
     }
 }
+
+impl<Tz: TimeZone> From<DateTime<Tz>> for Type {
+    fn from(dt: DateTime<Tz>) -> Self {
+        match dt.timestamp_nanos_opt() {
+            Some(nanos) => Type::SignedInteger(nanos),
+            None => {
+                // For dates before 1677-09-21, or after
+                // 2262-04-11, we're just going to return 0.
+                Type::SignedInteger(0)
+            }
+        }
+    }
+}
+
 impl<T> From<&T> for Type
 where
     T: Copy + Into<Type>,

--- a/influxdb/src/query/write_query.rs
+++ b/influxdb/src/query/write_query.rs
@@ -5,7 +5,6 @@
 use crate::query::line_proto_term::LineProtoTerm;
 use crate::query::{QueryType, ValidQuery};
 use crate::{Error, Query, Timestamp};
-use chrono::{DateTime, TimeZone};
 use std::fmt::{Display, Formatter};
 
 pub trait WriteType {
@@ -154,8 +153,9 @@ impl From<&str> for Type {
     }
 }
 
-impl<Tz: TimeZone> From<DateTime<Tz>> for Type {
-    fn from(dt: DateTime<Tz>) -> Self {
+#[cfg(feature = "chrono")]
+impl<Tz: chrono::TimeZone> From<chrono::DateTime<Tz>> for Type {
+    fn from(dt: chrono::DateTime<Tz>) -> Self {
         match dt.timestamp_nanos_opt() {
             Some(nanos) => Type::SignedInteger(nanos),
             None => {

--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -4,7 +4,7 @@ mod utilities;
 #[cfg(feature = "derive")]
 use influxdb::InfluxDbWriteable;
 
-use chrono::{Date, DateTime, Utc};
+use chrono::{DateTime, Utc};
 use influxdb::{Query, ReadQuery, Timestamp};
 
 #[cfg(feature = "serde")]

--- a/influxdb_derive/src/writeable.rs
+++ b/influxdb_derive/src/writeable.rs
@@ -10,6 +10,7 @@ use syn::{
 #[derive(Debug)]
 struct WriteableField {
     ident: Ident,
+    is_time: bool,
     is_tag: bool,
     is_ignore: bool,
 }
@@ -17,11 +18,13 @@ struct WriteableField {
 mod kw {
     use syn::custom_keyword;
 
+    custom_keyword!(time);
     custom_keyword!(tag);
     custom_keyword!(ignore);
 }
 
 enum FieldAttr {
+    Time(kw::time),
     Tag(kw::tag),
     Ignore(kw::ignore),
 }
@@ -29,7 +32,9 @@ enum FieldAttr {
 impl Parse for FieldAttr {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let lookahead = input.lookahead1();
-        if lookahead.peek(kw::tag) {
+        if lookahead.peek(kw::time) {
+            Ok(Self::Time(input.parse()?))
+        } else if lookahead.peek(kw::tag) {
             Ok(Self::Tag(input.parse()?))
         } else if lookahead.peek(kw::ignore) {
             Ok(Self::Ignore(input.parse()?))
@@ -52,6 +57,7 @@ impl TryFrom<Field> for WriteableField {
 
     fn try_from(field: Field) -> syn::Result<WriteableField> {
         let ident = field.ident.expect("fields without ident are not supported");
+        let mut has_time_attr = false;
         let mut is_tag = false;
         let mut is_ignore = false;
 
@@ -60,6 +66,7 @@ impl TryFrom<Field> for WriteableField {
                 Meta::List(list) if list.path.is_ident("influxdb") => {
                     for attr in syn::parse2::<FieldAttrs>(list.tokens)?.0 {
                         match attr {
+                            FieldAttr::Time(_) => has_time_attr = true,
                             FieldAttr::Tag(_) => is_tag = true,
                             FieldAttr::Ignore(_) => is_ignore = true,
                         }
@@ -69,8 +76,23 @@ impl TryFrom<Field> for WriteableField {
             }
         }
 
+        if [has_time_attr, is_tag, is_ignore]
+            .iter()
+            .filter(|&&b| b)
+            .count()
+            > 1
+        {
+            panic!("only one of time, tag, or ignore can be used");
+        }
+
+        // A field is considered a time field if:
+        // 1. It has the #[influxdb(time)] attribute, OR
+        // 2. It's named "time" and doesn't have #[influxdb(ignore)]
+        let is_time = has_time_attr || (ident == "time" && !is_ignore);
+
         Ok(WriteableField {
             ident,
+            is_time,
             is_tag,
             is_ignore,
         })
@@ -97,31 +119,44 @@ pub fn expand_writeable(input: DeriveInput) -> syn::Result<TokenStream> {
         }
     };
 
-    let time_field = format_ident!("time");
-    let time_field_str = time_field.to_string();
-    #[allow(clippy::cmp_owned)] // that's not how idents work clippy
-    let fields = match fields {
+    let writeable_fields: Vec<WriteableField> = match fields {
         Fields::Named(fields) => fields
             .named
             .into_iter()
-            .filter_map(|f| {
-                WriteableField::try_from(f)
-                    .map(|wf| {
-                        if !wf.is_ignore && wf.ident.to_string() != time_field_str {
-                            let ident = wf.ident;
-                            Some(match wf.is_tag {
-                                true => quote!(query.add_tag(stringify!(#ident), self.#ident)),
-                                false => quote!(query.add_field(stringify!(#ident), self.#ident)),
-                            })
-                        } else {
-                            None
-                        }
-                    })
-                    .transpose()
-            })
+            .map(WriteableField::try_from)
             .collect::<syn::Result<Vec<_>>>()?,
-        _ => panic!("a struct without named fields is not supported"),
+        _ => panic!("A struct without named fields is not supported!"),
     };
+
+    // Find the time field
+    let mut time_field = None;
+    for wf in &writeable_fields {
+        if wf.is_time {
+            if time_field.is_some() {
+                panic!("multiple time fields found!");
+            }
+            time_field = Some(wf.ident.clone());
+        }
+    }
+
+    // There must be exactly one time field
+    let time_field = time_field.expect("no time field found");
+
+    // Generate field assignments (excluding time and ignored fields)
+    let field_assignments = writeable_fields
+        .into_iter()
+        .filter_map(|wf| {
+            if wf.is_ignore || wf.is_time {
+                None
+            } else {
+                let ident = wf.ident;
+                Some(match wf.is_tag {
+                    true => quote!(query.add_tag(stringify!(#ident), self.#ident)),
+                    false => quote!(query.add_field(stringify!(#ident), self.#ident)),
+                })
+            }
+        })
+        .collect::<Vec<_>>();
 
     Ok(quote! {
         impl #impl_generics ::influxdb::InfluxDbWriteable for #ident #ty_generics #where_clause {
@@ -129,7 +164,7 @@ pub fn expand_writeable(input: DeriveInput) -> syn::Result<TokenStream> {
                 let timestamp: ::influxdb::Timestamp = self.#time_field.into();
                 let mut query = timestamp.into_query(name);
                 #(
-                    query = #fields;
+                    query = #field_assignments;
                 )*
                 query
             }

--- a/influxdb_derive/src/writeable.rs
+++ b/influxdb_derive/src/writeable.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,


### PR DESCRIPTION
## Description

This PR enables two new features in the crate:

1. Structs with `DateTime<Utc>` fields that become nanosecond-encoded uint64s
2. Setting a `DateTime<Utc>` field other than `time` to be the time field for the struct in the `InfluxDbWriteable` proc macro

For (1), this is now possible:

```rust
    #[derive(Debug, Deserialize, InfluxDbWriteable)]
    struct WeatherReading {
        time: DateTime<Utc>,
        humidity: i32,
        #[influxdb(tag)]
        wind_direction: String,
        forecast_time: DateTime<Utc>,
    }
```

Previously, `forecast_time` would have not worked. As type have to implement `From<T>` rather than `TryFrom<T>`, it defaults to zero if the `DateTime<Utc>` field is OOB.

For (2), we can now do:

```rust
    #[derive(Debug, Deserialize, InfluxDbWriteable)]
    struct WeatherReading {
        #[influxdb(time)]
        #[serde(rename = "time")]
        reading_time: DateTime<Utc>,
        humidity: i32,
        #[influxdb(tag)]
        wind_direction: String,
        forecast_time: DateTime<Utc>,
    }
```

The derive macro does sensible checks:

1. It enumerates the struct's fields and checks for any _tagged_ with `#[influxdb(time)]` _or_ named `time` and _not_ tagged with `#[influxdb(ignore)]`
2. If it finds more than one such field, it gives a compile error
3. If it finds no such fields, it gives a compile error
4. Otherwise, it uses the name of the field as the time of the created `WriteQuery` instance


### Have to dash but opening anyway, will be back soon!