### PR TITLE
Parametrize InfluxDB Version

### DIFF
--- a/benches/client.rs
+++ b/benches/client.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use influxdb::Error;
 use influxdb::InfluxDbWriteable;
+use influxdb::InfluxVersion1;
 use influxdb::{Client, ReadQuery};
 use std::sync::Arc;
 use std::time::Instant;
@@ -22,7 +23,7 @@ async fn main() {
     let number_of_total_requests = 20000;
     let concurrent_requests = 1000;
 
-    let client = Client::new(url, db_name);
+    let client: Client<InfluxVersion1> = Client::new(url, db_name);
     let concurrency_limit = Arc::new(Semaphore::new(concurrent_requests));
 
     prepare_influxdb(&client, db_name).await;
@@ -64,7 +65,7 @@ async fn main() {
     );
 }
 
-async fn prepare_influxdb(client: &Client, db_name: &str) {
+async fn prepare_influxdb<V>(client: &Client<V>, db_name: &str) {
     let create_db_stmt = format!("CREATE DATABASE {}", db_name);
     client
         .query(&ReadQuery::new(create_db_stmt))

--- a/influxdb/src/integrations/serde_integration/mod.rs
+++ b/influxdb/src/integrations/serde_integration/mod.rs
@@ -120,7 +120,7 @@ pub struct TaggedSeries<TAG, T> {
     pub values: Vec<T>,
 }
 
-impl Client {
+impl<V> Client<V, reqwest::Client> {
     pub async fn json_query(&self, q: ReadQuery) -> Result<DatabaseQueryResult, Error> {
         let query = q.build().map_err(|err| Error::InvalidQueryError {
             error: err.to_string(),

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -138,7 +138,7 @@ mod client;
 mod error;
 mod query;
 
-pub use client::Client;
+pub use client::{Client, InfluxVersion1, InfluxVersion2, InfluxVersion3};
 pub use error::Error;
 pub use query::{
     read_query::ReadQuery,

--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -10,7 +10,7 @@ use influxdb::{Query, ReadQuery, Timestamp};
 #[cfg(feature = "serde")]
 use serde_derive::Deserialize;
 
-use utilities::{assert_result_ok, create_client, create_db, delete_db, run_test};
+use utilities::{assert_result_ok, run_test};
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "derive", derive(InfluxDbWriteable))]

--- a/influxdb/tests/integration_tests_v2.rs
+++ b/influxdb/tests/integration_tests_v2.rs
@@ -15,7 +15,9 @@ use influxdb::{Client, Error, ReadQuery, Timestamp};
 async fn test_authed_write_and_read() {
     run_test(
         || async move {
-            let client = Client::new("http://127.0.0.1:2086", "mydb").with_token("admintoken");
+            use influxdb::InfluxVersion2;
+
+            let client: Client<InfluxVersion2> = Client::new("http://127.0.0.1:2086", "mydb").with_token("admintoken");
             let write_query = Timestamp::Hours(11)
                 .into_query("weather")
                 .add_field("temperature", 82);
@@ -31,7 +33,9 @@ async fn test_authed_write_and_read() {
             );
         },
         || async move {
-            let client = Client::new("http://127.0.0.1:2086", "mydb").with_token("admintoken");
+            use influxdb::InfluxVersion2;
+
+            let client: Client<InfluxVersion2> = Client::new("http://127.0.0.1:2086", "mydb").with_token("admintoken");
             let read_query = ReadQuery::new("DROP MEASUREMENT \"weather\"");
             let read_result = client.query(read_query).await;
             assert_result_ok(&read_result);
@@ -51,7 +55,9 @@ async fn test_wrong_authed_write_and_read() {
 
     run_test(
         || async move {
-            let client = Client::new("http://127.0.0.1:2086", "mydb").with_token("falsetoken");
+            use influxdb::InfluxVersion2;
+
+            let client: Client<InfluxVersion2> = Client::new("http://127.0.0.1:2086", "mydb").with_token("falsetoken");
             let write_query = Timestamp::Hours(11)
                 .into_query("weather")
                 .add_field("temperature", 82);
@@ -91,7 +97,9 @@ async fn test_non_authed_write_and_read() {
 
     run_test(
         || async move {
-            let non_authed_client = Client::new("http://127.0.0.1:2086", "mydb");
+            use influxdb::InfluxVersion2;
+
+            let non_authed_client: Client<InfluxVersion2> = Client::new("http://127.0.0.1:2086", "mydb");
             let write_query = Timestamp::Hours(11)
                 .into_query("weather")
                 .add_field("temperature", 82);

--- a/influxdb/tests/utilities.rs
+++ b/influxdb/tests/utilities.rs
@@ -1,4 +1,6 @@
 use futures_util::FutureExt;
+#[cfg(not(tarpaulin_include))]
+use influxdb::{InfluxVersion1, InfluxVersion2};
 use influxdb::{Client, Error, ReadQuery};
 use std::future::Future;
 use std::panic::{AssertUnwindSafe, UnwindSafe};
@@ -16,33 +18,64 @@ pub fn assert_result_ok<A: std::fmt::Debug, B: std::fmt::Debug>(result: &Result<
 
 #[allow(dead_code)]
 #[cfg(not(tarpaulin_include))]
-pub fn create_client<T>(db_name: T) -> Client
+pub fn create_client_v1<T>(db_name: T) -> Client<InfluxVersion1, reqwest::Client>
 where
     T: Into<String>,
 {
-    Client::new("http://127.0.0.1:8086", db_name)
+    Client::<InfluxVersion1>::new("http://127.0.0.1:8086", db_name)
 }
 
 #[allow(dead_code)]
 #[cfg(not(tarpaulin_include))]
-pub async fn create_db<T>(name: T) -> Result<String, Error>
+pub fn create_client_v2<T>(bucket: T) -> Client<InfluxVersion2, reqwest::Client>
+where
+    T: Into<String>,
+{
+    Client::<InfluxVersion2>::new("http://127.0.0.1:8086", bucket)
+}
+
+#[allow(dead_code)]
+#[cfg(not(tarpaulin_include))]
+pub async fn create_db_v1<T>(name: T) -> Result<String, Error>
 where
     T: Into<String>,
 {
     let test_name = name.into();
     let query = format!("CREATE DATABASE {test_name}");
-    create_client(test_name).query(ReadQuery::new(query)).await
+    create_client_v1(test_name).query(ReadQuery::new(query)).await
 }
 
 #[allow(dead_code)]
 #[cfg(not(tarpaulin_include))]
-pub async fn delete_db<T>(name: T) -> Result<String, Error>
+pub async fn create_db_v2<T>(name: T) -> Result<String, Error>
+where
+    T: Into<String>,
+{
+    let test_name = name.into();
+    let query = format!("CREATE DATABASE {test_name}");
+    create_client_v2(test_name).query(ReadQuery::new(query)).await
+}
+
+#[allow(dead_code)]
+#[cfg(not(tarpaulin_include))]
+pub async fn delete_db_v1<T>(name: T) -> Result<String, Error>
 where
     T: Into<String>,
 {
     let test_name = name.into();
     let query = format!("DROP DATABASE {test_name}");
-    create_client(test_name).query(ReadQuery::new(query)).await
+    create_client_v1(test_name).query(ReadQuery::new(query)).await
+}
+
+#[allow(dead_code)]
+#[cfg(not(tarpaulin_include))]
+pub async fn delete_db_v2<T>(name: T) -> Result<String, Error>
+where
+    T: Into<String>,
+{
+    let test_name = name.into();
+    let query = format!("DROP DATABASE {test_name}");
+    create_client_v2(test_name).query(ReadQuery::new(query)).await
 }
 
 #[cfg(not(tarpaulin_include))]


### PR DESCRIPTION
## Description

More and more feature keep getting added or wished for that depend on specific versions of InfluxDB (#132, #136, #165). This PR creates a `PhantomData` version field in the client. That way, we can implement traits for version specific features and do not mix feature that might be incompatible with a connected database.

I am looking for first feedback about this design / approch before I port over any other version related code.

### Checklist
- [ ] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy
  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features serde,derive,reqwest-client-rustls -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features serde,derive,hyper-client -- -D warnings`
- [ ] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
- [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
