### PR TITLE
[#147] Remove `surf` support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,7 @@
 
 ### Checklist
 - [ ] Formatted code using `cargo fmt --all`
-- [ ] Linted code using clippy
-  - [ ] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features serde,derive,reqwest-client-rustls -- -D warnings`
-  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features serde,derive,hyper-client -- -D warnings`
+- [ ] Linted code using clippy with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features serde,derive,reqwest-client-rustls -- -D warnings`
 - [ ] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
 - [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
 - [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,10 +122,6 @@ jobs:
             toolchain: stable
             nightly: false
         http-backend:
-          - curl-client
-          - h1-client
-          - h1-client-rustls
-          - hyper-client
           - reqwest-client-rustls
           - reqwest-client-native-tls
           - reqwest-client-native-tls-vendored

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,8 +31,6 @@ jobs:
         run: cargo --config 'resolver.incompatible-rust-versions="fallback"' update
       - name: Check Clippy lints (reqwest)
         run: cargo clippy --manifest-path influxdb/Cargo.toml --locked --all-targets --no-default-features --features serde,derive,reqwest-client-rustls -- -D warnings
-      - name: Check Clippy lints (surf)
-        run: cargo clippy --manifest-path influxdb/Cargo.toml --locked --all-targets --no-default-features --features serde,derive,hyper-client -- -D warnings
 
   # this checks that the code is formatted with rustfmt
   rustfmt:

--- a/README.md
+++ b/README.md
@@ -32,25 +32,22 @@
 
 Pull requests are always welcome. See [Contributing][__link0] and [Code of Conduct][__link1]. For a list of past changes, see [CHANGELOG.md][__link2].
 
-
 ### Currently Supported Features
 
- - Reading and writing to InfluxDB
- - Optional Serde support for deserialization
- - Running multiple queries in one request (e.g. `SELECT * FROM weather_berlin; SELECT * FROM weather_london`)
- - Writing single or multiple measurements in one request (e.g. `WriteQuery` or `Vec<WriteQuery>` argument)
- - Authenticated and unauthenticated connections
- - `async`/`await` support
- - `#[derive(InfluxDbWriteable)]` derive macro for writing / reading into structs
- - `GROUP BY` support
- - Tokio and async-std support (see example below) or [available backends][__link3]
- - Swappable HTTP backends ([see below](#Choice-of-HTTP-backend))
-
+* Reading and writing to InfluxDB
+* Optional Serde support for deserialization
+* Running multiple queries in one request (e.g. `SELECT * FROM weather_berlin; SELECT * FROM weather_london`)
+* Writing single or multiple measurements in one request (e.g. `WriteQuery` or `Vec<WriteQuery>` argument)
+* Authenticated and unauthenticated connections
+* `async`/`await` support
+* `#[derive(InfluxDbWriteable)]` derive macro for writing / reading into structs
+* `GROUP BY` support
+* Tokio and async-std support (see example below) or [available backends][__link3]
+* Swappable HTTP backends ([see below](#Choice-of-HTTP-backend))
 
 ## Quickstart
 
 Add the following to your `Cargo.toml`
-
 
 ```toml
 influxdb = { version = "0.7.2", features = ["derive"] }
@@ -58,13 +55,11 @@ influxdb = { version = "0.7.2", features = ["derive"] }
 
 For an example with using Serde deserialization, please refer to [serde_integration][__link4]
 
-
 ```rust
 use chrono::{DateTime, Utc};
 use influxdb::{Client, Error, InfluxDbWriteable, ReadQuery, Timestamp};
 
 #[tokio::main]
-// or #[async_std::main] if you prefer
 async fn main() -> Result<(), Error> {
     // Connect to db `test` on `http://localhost:8086`
     let client = Client::new("http://localhost:8086", "test");
@@ -104,67 +99,57 @@ async fn main() -> Result<(), Error> {
 }
 ```
 
-For further examples, check out the integration tests in `tests/integration_tests.rs` in the repository.
-
+For further examples, check out the integration tests in `tests/integration_tests.rs`
+in the repository.
 
 ## Choice of HTTP backend
 
 To communicate with InfluxDB, you can choose the HTTP backend to be used configuring the appropriate feature. We recommend sticking with the default reqwest-based client, unless you really need async-std compatibility.
 
- - **[hyper][__link5]** (through reqwest, used by default), with [rustls][__link6]
-	```toml
-	influxdb = { version = "0.7.2", features = ["derive"] }
-	```
-	
-	
- - **[hyper][__link7]** (through reqwest), with native TLS (OpenSSL)
-	```toml
-	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "reqwest-client-native-tls"] }
-	```
-	
-	
- - **[hyper][__link8]** (through reqwest), with vendored native TLS (OpenSSL)
-	```toml
-	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "reqwest-client-native-tls-vendored"] }
-	```
-	
-	
- - **[curl][__link9]**, using [libcurl][__link10]
-	```toml
-	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "curl-client"] }
-	```
-	
-	
- - **[async-h1][__link11]** with native TLS (OpenSSL)
-	```toml
-	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "h1-client"] }
-	```
-	
-	
- - **[async-h1][__link12]** with [rustls][__link13]
-	```toml
-	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "h1-client-rustls"] }
-	```
-	
-	
- - WebAssembly’s `window.fetch`, via `web-sys` and **[wasm-bindgen][__link14]**
-	```toml
-	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "wasm-client"] }
-	```
-	
-	
+* **[hyper][__link5]** (through reqwest, used by default), with [rustls][__link6]
+  ```toml
+  influxdb = { version = "0.7.2", features = ["derive"] }
+  ```
 
+* **[hyper][__link7]** (through reqwest), with native TLS (OpenSSL)
+  ```toml
+  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "reqwest-client-native-tls"] }
+  ```
+
+* **[hyper][__link8]** (through reqwest), with vendored native TLS (OpenSSL)
+  ```toml
+  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "reqwest-client-native-tls-vendored"] }
+  ```
+
+* **[curl][__link9]**, using [libcurl][__link10]
+  ```toml
+  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "curl-client"] }
+  ```
+
+* **[async-h1][__link11]** with native TLS (OpenSSL)
+  ```toml
+  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "h1-client"] }
+  ```
+
+* **[async-h1][__link12]** with [rustls][__link13]
+  ```toml
+  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "h1-client-rustls"] }
+  ```
+
+* WebAssembly’s `window.fetch`, via `web-sys` and **[wasm-bindgen][__link14]**
+  ```toml
+  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "wasm-client"] }
+  ```
 
 ## License
 
-[![License: MIT][__link15]][__link16]
-
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)][__link15]
 
 
 @ 2020-2024 Gero Gerke, msrd0 and [contributors].
 
  [contributors]: https://github.com/influxdb-rs/influxdb-rust/graphs/contributors
- [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEGzJ_QpW55zB1G0S-TER-rIfLG2gXv8EYBG3jG1nuXXn-kdx-YXKEG9BSlXCisRNxGyudsuAyPU_iG753wscIDhrEG2I5swlqlF_MYWSBgmhpbmZsdXhkYmUwLjcuMg
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGzJ_QpW55zB1G0S-TER-rIfLG2gXv8EYBG3jG1nuXXn-kdx-YXKEG4NMwSc-atpuGyQ3O7T4Ur42GzFqIg36Zfn7G7roc8ix9SwDYWSBgmhpbmZsdXhkYmUwLjcuMg
  [__link0]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CONTRIBUTING.md
  [__link1]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CODE_OF_CONDUCT.md
  [__link10]: https://curl.se/libcurl/
@@ -172,8 +157,7 @@ To communicate with InfluxDB, you can choose the HTTP backend to be used configu
  [__link12]: https://github.com/http-rs/async-h1
  [__link13]: https://github.com/ctz/rustls
  [__link14]: https://github.com/rustwasm/wasm-bindgen
- [__link15]: https://img.shields.io/badge/License-MIT-yellow.svg
- [__link16]: https://opensource.org/licenses/MIT
+ [__link15]: https://opensource.org/licenses/MIT
  [__link2]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CHANGELOG.md
  [__link3]: https://github.com/influxdb-rs/influxdb-rust/blob/main/influxdb/Cargo.toml
  [__link4]: https://docs.rs/influxdb/0.7.2/influxdb/?search=integrations::serde_integration

--- a/README.md
+++ b/README.md
@@ -121,43 +121,17 @@ To communicate with InfluxDB, you can choose the HTTP backend to be used configu
   influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "reqwest-client-native-tls-vendored"] }
   ```
 
-* **[curl][__link9]**, using [libcurl][__link10]
-  ```toml
-  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "curl-client"] }
-  ```
-
-* **[async-h1][__link11]** with native TLS (OpenSSL)
-  ```toml
-  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "h1-client"] }
-  ```
-
-* **[async-h1][__link12]** with [rustls][__link13]
-  ```toml
-  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "h1-client-rustls"] }
-  ```
-
-* WebAssembly’s `window.fetch`, via `web-sys` and **[wasm-bindgen][__link14]**
-  ```toml
-  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "wasm-client"] }
-  ```
-
 ## License
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)][__link15]
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)][__link9]
 
 
 @ 2020-2024 Gero Gerke, msrd0 and [contributors].
 
  [contributors]: https://github.com/influxdb-rs/influxdb-rust/graphs/contributors
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGzJ_QpW55zB1G0S-TER-rIfLG2gXv8EYBG3jG1nuXXn-kdx-YXKEG4NMwSc-atpuGyQ3O7T4Ur42GzFqIg36Zfn7G7roc8ix9SwDYWSBgmhpbmZsdXhkYmUwLjcuMg
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGzJ_QpW55zB1G0S-TER-rIfLG2gXv8EYBG3jG1nuXXn-kdx-YXKEG8LHWNBBuXgSGz-2Lrx4E_kTG0bJiXb6A8zNG9GhXhvU8L0xYWSBgmhpbmZsdXhkYmUwLjcuMg
  [__link0]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CONTRIBUTING.md
  [__link1]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CODE_OF_CONDUCT.md
- [__link10]: https://curl.se/libcurl/
- [__link11]: https://github.com/http-rs/async-h1
- [__link12]: https://github.com/http-rs/async-h1
- [__link13]: https://github.com/ctz/rustls
- [__link14]: https://github.com/rustwasm/wasm-bindgen
- [__link15]: https://opensource.org/licenses/MIT
  [__link2]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CHANGELOG.md
  [__link3]: https://github.com/influxdb-rs/influxdb-rust/blob/main/influxdb/Cargo.toml
  [__link4]: https://docs.rs/influxdb/0.7.2/influxdb/?search=integrations::serde_integration
@@ -165,5 +139,5 @@ To communicate with InfluxDB, you can choose the HTTP backend to be used configu
  [__link6]: https://github.com/ctz/rustls
  [__link7]: https://github.com/hyperium/hyper
  [__link8]: https://github.com/hyperium/hyper
- [__link9]: https://github.com/alexcrichton/curl-rust
+ [__link9]: https://opensource.org/licenses/MIT
 

--- a/README.md
+++ b/README.md
@@ -32,28 +32,32 @@
 
 Pull requests are always welcome. See [Contributing][__link0] and [Code of Conduct][__link1]. For a list of past changes, see [CHANGELOG.md][__link2].
 
+
 ### Currently Supported Features
 
-* Reading and writing to InfluxDB
-* Optional Serde support for deserialization
-* Running multiple queries in one request (e.g. `SELECT * FROM weather_berlin; SELECT * FROM weather_london`)
-* Writing single or multiple measurements in one request (e.g. `WriteQuery` or `Vec<WriteQuery>` argument)
-* Authenticated and unauthenticated connections
-* `async`/`await` support
-* `#[derive(InfluxDbWriteable)]` derive macro for writing / reading into structs
-* `GROUP BY` support
-* Tokio and async-std support (see example below) or [available backends][__link3]
-* Swappable HTTP backends ([see below](#Choice-of-HTTP-backend))
+ - Reading and writing to InfluxDB
+ - Optional Serde support for deserialization
+ - Running multiple queries in one request (e.g. `SELECT * FROM weather_berlin; SELECT * FROM weather_london`)
+ - Writing single or multiple measurements in one request (e.g. `WriteQuery` or `Vec<WriteQuery>` argument)
+ - Authenticated and unauthenticated connections
+ - `async`/`await` support
+ - `#[derive(InfluxDbWriteable)]` derive macro for writing / reading into structs
+ - `GROUP BY` support
+ - Tokio and async-std support (see example below) or [available backends][__link3]
+ - Swappable HTTP backends ([see below](#Choice-of-HTTP-backend))
+
 
 ## Quickstart
 
 Add the following to your `Cargo.toml`
+
 
 ```toml
 influxdb = { version = "0.7.2", features = ["derive"] }
 ```
 
 For an example with using Serde deserialization, please refer to [serde_integration][__link4]
+
 
 ```rust
 use chrono::{DateTime, Utc};
@@ -100,70 +104,75 @@ async fn main() -> Result<(), Error> {
 }
 ```
 
-For further examples, check out the integration tests in `tests/integration_tests.rs`
-in the repository.
+For further examples, check out the integration tests in `tests/integration_tests.rs` in the repository.
+
 
 ## Choice of HTTP backend
 
 To communicate with InfluxDB, you can choose the HTTP backend to be used configuring the appropriate feature. We recommend sticking with the default reqwest-based client, unless you really need async-std compatibility.
 
-* **[hyper][__link5]** (through reqwest, used by default), with [rustls][__link6]
-  ```toml
-  influxdb = { version = "0.7.2", features = ["derive"] }
-  ```
+ - **[hyper][__link5]** (through reqwest, used by default), with [rustls][__link6]
+	```toml
+	influxdb = { version = "0.7.2", features = ["derive"] }
+	```
+	
+	
+ - **[hyper][__link7]** (through reqwest), with native TLS (OpenSSL)
+	```toml
+	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "reqwest-client-native-tls"] }
+	```
+	
+	
+ - **[hyper][__link8]** (through reqwest), with vendored native TLS (OpenSSL)
+	```toml
+	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "reqwest-client-native-tls-vendored"] }
+	```
+	
+	
+ - **[curl][__link9]**, using [libcurl][__link10]
+	```toml
+	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "curl-client"] }
+	```
+	
+	
+ - **[async-h1][__link11]** with native TLS (OpenSSL)
+	```toml
+	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "h1-client"] }
+	```
+	
+	
+ - **[async-h1][__link12]** with [rustls][__link13]
+	```toml
+	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "h1-client-rustls"] }
+	```
+	
+	
+ - WebAssembly’s `window.fetch`, via `web-sys` and **[wasm-bindgen][__link14]**
+	```toml
+	influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "wasm-client"] }
+	```
+	
+	
 
-* **[hyper][__link7]** (through reqwest), with native TLS (OpenSSL)
-  ```toml
-  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "reqwest-client-native-tls"] }
-  ```
-
-* **[hyper][__link8]** (through reqwest), with vendored native TLS (OpenSSL)
-  ```toml
-  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "reqwest-client-native-tls-vendored"] }
-  ```
-
-* **[hyper][__link9]** (through surf), use this if you need tokio 0.2 compatibility
-  ```toml
-  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "hyper-client"] }
-  ```
-
-* **[curl][__link10]**, using [libcurl][__link11]
-  ```toml
-  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "curl-client"] }
-  ```
-
-* **[async-h1][__link12]** with native TLS (OpenSSL)
-  ```toml
-  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "h1-client"] }
-  ```
-
-* **[async-h1][__link13]** with [rustls][__link14]
-  ```toml
-  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "h1-client-rustls"] }
-  ```
-
-* WebAssembly’s `window.fetch`, via `web-sys` and **[wasm-bindgen][__link15]**
-  ```toml
-  influxdb = { version = "0.7.2", default-features = false, features = ["derive", "serde", "wasm-client"] }
-  ```
 
 ## License
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)][__link16]
+[![License: MIT][__link15]][__link16]
+
 
 
 @ 2020-2024 Gero Gerke, msrd0 and [contributors].
 
  [contributors]: https://github.com/influxdb-rs/influxdb-rust/graphs/contributors
- [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEGzJ_QpW55zB1G0S-TER-rIfLG2gXv8EYBG3jG1nuXXn-kdx-YXKEG1LaAVLASZMqG5J2qfpyCvbMG_Rohh5BobOmG0DqLv5454SZYWSBgmhpbmZsdXhkYmUwLjcuMg
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEGzJ_QpW55zB1G0S-TER-rIfLG2gXv8EYBG3jG1nuXXn-kdx-YXKEG9BSlXCisRNxGyudsuAyPU_iG753wscIDhrEG2I5swlqlF_MYWSBgmhpbmZsdXhkYmUwLjcuMg
  [__link0]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CONTRIBUTING.md
  [__link1]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CODE_OF_CONDUCT.md
- [__link10]: https://github.com/alexcrichton/curl-rust
- [__link11]: https://curl.se/libcurl/
+ [__link10]: https://curl.se/libcurl/
+ [__link11]: https://github.com/http-rs/async-h1
  [__link12]: https://github.com/http-rs/async-h1
- [__link13]: https://github.com/http-rs/async-h1
- [__link14]: https://github.com/ctz/rustls
- [__link15]: https://github.com/rustwasm/wasm-bindgen
+ [__link13]: https://github.com/ctz/rustls
+ [__link14]: https://github.com/rustwasm/wasm-bindgen
+ [__link15]: https://img.shields.io/badge/License-MIT-yellow.svg
  [__link16]: https://opensource.org/licenses/MIT
  [__link2]: https://github.com/influxdb-rs/influxdb-rust/blob/main/CHANGELOG.md
  [__link3]: https://github.com/influxdb-rs/influxdb-rust/blob/main/influxdb/Cargo.toml
@@ -172,5 +181,5 @@ To communicate with InfluxDB, you can choose the HTTP backend to be used configu
  [__link6]: https://github.com/ctz/rustls
  [__link7]: https://github.com/hyperium/hyper
  [__link8]: https://github.com/hyperium/hyper
- [__link9]: https://github.com/hyperium/hyper
+ [__link9]: https://github.com/alexcrichton/curl-rust
 

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -23,7 +23,6 @@ http = "0.2.4"
 influxdb_derive = { version = "0.5.1", optional = true }
 lazy-regex = "3.1"
 reqwest = { version = "0.11.4", default-features = false, optional = true }
-surf = { version = "2.2.0", default-features = false, optional = true }
 serde = { version = "1.0.186", optional = true }
 serde_derive = { version = "1.0.186", optional = true }
 serde_json = { version = "1.0.48", optional = true }
@@ -35,16 +34,10 @@ derive = ["dep:influxdb_derive"]
 serde = ["dep:serde", "dep:serde_derive", "dep:serde_json"]
 
 # http clients
-curl-client = ["surf", "surf/curl-client"]
-h1-client = ["surf", "surf/h1-client"]
-h1-client-rustls = ["surf", "surf/h1-client-rustls"]
-hyper-client = ["surf", "surf/hyper-client"]
 reqwest-client-rustls = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
 reqwest-client-native-tls = ["reqwest", "reqwest/native-tls-alpn"]
 reqwest-client-native-tls-vendored = ["reqwest", "reqwest/native-tls-vendored"]
-wasm-client = ["surf", "surf/wasm-client"]
 
 [dev-dependencies]
-async-std = { version = "1.6.5", features = ["attributes", "tokio02", "tokio1"] }
 indoc = "1.0"
 tokio = { version = "1.7", features = ["macros", "rt-multi-thread"] }

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -34,9 +34,9 @@ derive = ["dep:influxdb_derive"]
 serde = ["dep:serde", "dep:serde_derive", "dep:serde_json"]
 
 # http clients
-reqwest-client-rustls = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
-reqwest-client-native-tls = ["reqwest", "reqwest/native-tls-alpn"]
-reqwest-client-native-tls-vendored = ["reqwest", "reqwest/native-tls-vendored"]
+reqwest-client-rustls = ["reqwest/rustls-tls-webpki-roots"]
+reqwest-client-native-tls = ["reqwest/native-tls-alpn"]
+reqwest-client-native-tls-vendored = ["reqwest/native-tls-vendored"]
 
 [dev-dependencies]
 indoc = "1.0"

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = "0.3.17"
 http = "0.2.4"
 influxdb_derive = { version = "0.5.1", optional = true }
 lazy-regex = "3.1"
-reqwest = { version = "0.11.4", default-features = false, optional = true }
+reqwest = { version = "0.11.4", default-features = false }
 serde = { version = "1.0.186", optional = true }
 serde_derive = { version = "1.0.186", optional = true }
 serde_json = { version = "1.0.48", optional = true }

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -194,7 +194,7 @@ impl Client {
     /// use influxdb::InfluxDbWriteable;
     /// use std::time::{SystemTime, UNIX_EPOCH};
     ///
-    /// # #[async_std::main]
+    /// # #[tokio::main]
     /// # async fn main() -> Result<(), influxdb::Error> {
     /// let start = SystemTime::now();
     /// let since_the_epoch = start

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -16,7 +16,6 @@
 //! ```
 
 use futures_util::TryFutureExt;
-#[cfg(feature = "reqwest")]
 use reqwest::{Client as HttpClient, RequestBuilder, Response as HttpResponse};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Debug, Formatter};
@@ -166,7 +165,6 @@ impl Client {
         const BUILD_HEADER: &str = "X-Influxdb-Build";
         const VERSION_HEADER: &str = "X-Influxdb-Version";
 
-        #[cfg(feature = "reqwest")]
         let (build, version) = {
             let hdrs = res.headers();
             (
@@ -256,7 +254,6 @@ impl Client {
             .await?;
         check_status(&res)?;
 
-        #[cfg(feature = "reqwest")]
         let body = res.text();
 
         let s = body.await.map_err(|_| Error::DeserializationError {

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -21,8 +21,6 @@ use reqwest::{Client as HttpClient, RequestBuilder, Response as HttpResponse};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
-#[cfg(feature = "surf")]
-use surf::{Client as HttpClient, RequestBuilder, Response as HttpResponse};
 
 use crate::query::QueryType;
 use crate::Error;
@@ -178,11 +176,6 @@ impl Client {
             )
         };
 
-        #[cfg(feature = "surf")]
-        let build = res.header(BUILD_HEADER).map(|value| value.as_str());
-        #[cfg(feature = "surf")]
-        let version = res.header(VERSION_HEADER).map(|value| value.as_str());
-
         Ok((build.unwrap().to_owned(), version.unwrap().to_owned()))
     }
 
@@ -254,11 +247,6 @@ impl Client {
             }
         };
 
-        #[cfg(feature = "surf")]
-        let request_builder = request_builder.map_err(|err| Error::UrlConstructionError {
-            error: err.to_string(),
-        })?;
-
         let res = self
             .auth_if_needed(request_builder)
             .send()
@@ -270,10 +258,6 @@ impl Client {
 
         #[cfg(feature = "reqwest")]
         let body = res.text();
-        #[cfg(feature = "surf")]
-        let mut res = res;
-        #[cfg(feature = "surf")]
-        let body = res.body_string();
 
         let s = body.await.map_err(|_| Error::DeserializationError {
             error: "response could not be converted to UTF-8".into(),

--- a/influxdb/src/integrations/serde_integration/mod.rs
+++ b/influxdb/src/integrations/serde_integration/mod.rs
@@ -21,7 +21,7 @@
 //!     weather: WeatherWithoutCityName,
 //! }
 //!
-//! # #[async_std::main]
+//! # #[tokio::main]
 //! # async fn main() -> Result<(), influxdb::Error> {
 //! let client = Client::new("http://localhost:8086", "test");
 //! let query = Query::raw_read_query(
@@ -152,7 +152,7 @@ impl Client {
                 error: err.to_string(),
             })?;
         check_status(&res)?;
-        
+
         let body = res.bytes();
 
         let body = body.await.map_err(|err| Error::ProtocolError {

--- a/influxdb/src/integrations/serde_integration/mod.rs
+++ b/influxdb/src/integrations/serde_integration/mod.rs
@@ -152,8 +152,7 @@ impl Client {
                 error: err.to_string(),
             })?;
         check_status(&res)?;
-
-        #[cfg(feature = "reqwest")]
+        
         let body = res.bytes();
 
         let body = body.await.map_err(|err| Error::ProtocolError {

--- a/influxdb/src/integrations/serde_integration/mod.rs
+++ b/influxdb/src/integrations/serde_integration/mod.rs
@@ -145,11 +145,6 @@ impl Client {
         }
         let request_builder = request_builder.query(&parameters);
 
-        #[cfg(feature = "surf")]
-        let request_builder = request_builder.map_err(|err| Error::UrlConstructionError {
-            error: err.to_string(),
-        })?;
-
         let res = request_builder
             .send()
             .await
@@ -160,10 +155,6 @@ impl Client {
 
         #[cfg(feature = "reqwest")]
         let body = res.bytes();
-        #[cfg(feature = "surf")]
-        let mut res = res;
-        #[cfg(feature = "surf")]
-        let body = res.body_bytes();
 
         let body = body.await.map_err(|err| Error::ProtocolError {
             error: err.to_string(),

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -78,14 +78,6 @@
 #![doc = cargo_toml!(indent="\t", default-features = false, "derive", "serde", "reqwest-client-native-tls")]
 //! - **[hyper](https://github.com/hyperium/hyper)** (through reqwest), with vendored native TLS (OpenSSL)
 #![doc = cargo_toml!(indent="\t", default-features = false, "derive", "serde", "reqwest-client-native-tls-vendored")]
-//! - **[curl](https://github.com/alexcrichton/curl-rust)**, using [libcurl](https://curl.se/libcurl/)
-#![doc = cargo_toml!(indent="\t", default-features = false, "derive", "serde", "curl-client")]
-//! - **[async-h1](https://github.com/http-rs/async-h1)** with native TLS (OpenSSL)
-#![doc = cargo_toml!(indent="\t", default-features = false, "derive", "serde", "h1-client")]
-//! - **[async-h1](https://github.com/http-rs/async-h1)** with [rustls](https://github.com/ctz/rustls)
-#![doc = cargo_toml!(indent="\t", default-features = false, "derive", "serde", "h1-client-rustls")]
-//! - WebAssembly's `window.fetch`, via `web-sys` and **[wasm-bindgen](https://github.com/rustwasm/wasm-bindgen)**
-#![doc = cargo_toml!(indent="\t", default-features = false, "derive", "serde", "wasm-client")]
 //!
 //! # License
 //!

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -79,8 +79,6 @@
 #![doc = cargo_toml!(indent="\t", default-features = false, "derive", "serde", "reqwest-client-native-tls")]
 //! - **[hyper](https://github.com/hyperium/hyper)** (through reqwest), with vendored native TLS (OpenSSL)
 #![doc = cargo_toml!(indent="\t", default-features = false, "derive", "serde", "reqwest-client-native-tls-vendored")]
-//! - **[hyper](https://github.com/hyperium/hyper)** (through surf), use this if you need tokio 0.2 compatibility
-#![doc = cargo_toml!(indent="\t", default-features = false, "derive", "serde", "hyper-client")]
 //! - **[curl](https://github.com/alexcrichton/curl-rust)**, using [libcurl](https://curl.se/libcurl/)
 #![doc = cargo_toml!(indent="\t", default-features = false, "derive", "serde", "curl-client")]
 //! - **[async-h1](https://github.com/http-rs/async-h1)** with native TLS (OpenSSL)
@@ -127,12 +125,6 @@ macro_rules! cargo_toml_private {
     };
 }
 use cargo_toml_private;
-
-#[cfg(all(feature = "reqwest", feature = "surf"))]
-compile_error!("You need to choose between reqwest and surf; enabling both is not supported");
-
-#[cfg(not(any(feature = "reqwest", feature = "surf")))]
-compile_error!("You need to choose an http client; consider not disabling default features");
 
 mod client;
 mod error;

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -26,7 +26,6 @@
 //! use influxdb::{Client, Error, InfluxDbWriteable, ReadQuery, Timestamp};
 //!
 //! #[tokio::main]
-//! // or #[async_std::main] if you prefer
 //! async fn main() -> Result<(), Error> {
 //!     // Connect to db `test` on `http://localhost:8086`
 //!     let client = Client::new("http://localhost:8086", "test");

--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -51,7 +51,7 @@ fn test_build_query() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_derive_simple_write() {
     const TEST_NAME: &str = "test_derive_simple_write";
@@ -82,7 +82,7 @@ async fn test_derive_simple_write() {
 /// This integration tests that writing data and retrieving the data again is working
 #[cfg(feature = "derive")]
 #[cfg(feature = "serde")]
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_option() {
     const TEST_NAME: &str = "test_write_and_read_option";

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -520,10 +520,7 @@ async fn test_json_query_tagged() {
 /// is equal to the data which was written to the database
 /// (tested with tokio)
 #[tokio::test]
-#[cfg(all(
-    feature = "serde",
-    not(any(tarpaulin_include))
-))]
+#[cfg(all(feature = "serde", not(any(tarpaulin_include))))]
 async fn test_json_query_vec() {
     const TEST_NAME: &str = "test_json_query_vec";
 

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -13,26 +13,9 @@ use influxdb::{Client, Error, ReadQuery, Timestamp};
 
 /// INTEGRATION TEST
 ///
-/// This test case tests whether the InfluxDB server can be connected to and gathers info about it - tested with async_std
-#[async_std::test]
-#[cfg(not(tarpaulin_include))]
-async fn test_ping_influx_db_async_std() {
-    let client = create_client("notusedhere");
-    let result = client.ping().await;
-    assert_result_ok(&result);
-
-    let (build, version) = result.unwrap();
-    assert!(!build.is_empty(), "Build should not be empty");
-    assert!(!version.is_empty(), "Build should not be empty");
-
-    println!("build: {build} version: {version}");
-}
-
-/// INTEGRATION TEST
-///
 /// This test case tests whether the InfluxDB server can be connected to and gathers info about it - tested with tokio 1.0
 #[tokio::test]
-#[cfg(not(any(tarpaulin_include, feature = "hyper-client")))]
+#[cfg(not(any(tarpaulin_include)))]
 async fn test_ping_influx_db_tokio() {
     let client = create_client("notusedhere");
     let result = client.ping().await;
@@ -48,7 +31,7 @@ async fn test_ping_influx_db_tokio() {
 /// INTEGRATION TEST
 ///
 /// This test case tests connection error
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_connection_error() {
     let test_name = "test_connection_error";
@@ -69,7 +52,7 @@ async fn test_connection_error() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_authed_write_and_read() {
     const TEST_NAME: &str = "test_authed_write_and_read";
@@ -117,7 +100,7 @@ async fn test_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_wrong_authed_write_and_read() {
     use http::StatusCode;
@@ -189,7 +172,7 @@ async fn test_wrong_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_non_authed_write_and_read() {
     use http::StatusCode;
@@ -247,7 +230,7 @@ async fn test_non_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_field() {
     const TEST_NAME: &str = "test_write_field";
@@ -280,7 +263,7 @@ async fn test_write_and_read_field() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the authentication on json reads
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_non_authed_read() {
@@ -327,7 +310,7 @@ async fn test_json_non_authed_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the authentication on json reads
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_authed_read() {
@@ -364,7 +347,7 @@ async fn test_json_authed_read() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_option() {
@@ -423,7 +406,7 @@ async fn test_write_and_read_option() {
 ///
 /// This test case tests whether JSON can be decoded from a InfluxDB response and whether that JSON
 /// is equal to the data which was written to the database
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_query() {
@@ -473,7 +456,7 @@ async fn test_json_query() {
 ///
 /// This test case tests whether the response to a GROUP BY can be parsed by
 /// deserialize_next_tagged into a tags struct
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_query_tagged() {
@@ -539,7 +522,7 @@ async fn test_json_query_tagged() {
 #[tokio::test]
 #[cfg(all(
     feature = "serde",
-    not(any(tarpaulin_include, feature = "hyper-client"))
+    not(any(tarpaulin_include))
 ))]
 async fn test_json_query_vec() {
     const TEST_NAME: &str = "test_json_query_vec";
@@ -587,7 +570,7 @@ async fn test_json_query_vec() {
 /// INTEGRATION TEST
 ///
 /// This integration test tests whether using the wrong query method fails building the query
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_serde_multi_query() {
@@ -661,7 +644,7 @@ async fn test_serde_multi_query() {
 /// INTEGRATION TEST
 ///
 /// This integration test tests whether using the wrong query method fails building the query
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_wrong_query_errors() {

--- a/influxdb/tests/integration_tests_v2.rs
+++ b/influxdb/tests/integration_tests_v2.rs
@@ -10,7 +10,7 @@ use influxdb::{Client, Error, ReadQuery, Timestamp};
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin))]
 async fn test_authed_write_and_read() {
     run_test(
@@ -44,7 +44,7 @@ async fn test_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin))]
 async fn test_wrong_authed_write_and_read() {
     use http::StatusCode;
@@ -84,7 +84,7 @@ async fn test_wrong_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin))]
 async fn test_non_authed_write_and_read() {
     use http::StatusCode;


### PR DESCRIPTION
Fixes #147

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy
  - [x] with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features serde,derive,reqwest-client-rustls -- -D warnings`
  - [ ] with surf feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features serde,derive,hyper-client -- -D warnings`
- [x] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
- [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
