### PR TITLE
Update Rust Edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Gero Gerke <git@gero.dev>", "Dominic <git@msrd0.de>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.67.1"
 license = "MIT"
 repository = "https://github.com/influxdb-rs/influxdb-rust"

--- a/influxdb/src/query/mod.rs
+++ b/influxdb/src/query/mod.rs
@@ -255,7 +255,6 @@ mod tests {
         MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MICRO, NANOS_PER_MILLI, SECONDS_PER_MINUTE,
     };
     use crate::query::{Timestamp, ValidQuery};
-    use std::convert::TryInto;
     #[test]
     fn test_equality_str() {
         assert_eq!(ValidQuery::from("hello"), "hello");

--- a/influxdb_derive/src/writeable.rs
+++ b/influxdb_derive/src/writeable.rs
@@ -1,6 +1,5 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use std::convert::TryFrom;
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,


### PR DESCRIPTION
Our MSRV is 1.67.1, edition 2021 was introduced in 1.56.  
We are already using resolver 2, which became default in 2021.  
Safe to say we can just migrate to 2021 completely at this point.
