### PR TITLE
Update dependencies

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 chrono = { version = "0.4.11", features = ["serde"] }
 futures = "0.3.4"
 influxdb = { path = "../influxdb", features = ["derive"] }
-tokio = { version =  "0.2.22", features = ["macros", "rt-threaded", "sync"] }
+tokio = { version =  "1.38.0", features = ["macros", "rt-multi-thread", "sync"] }
 
 [[bench]]
 name = "client"

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -24,15 +24,15 @@ required-features = ["chrono"]
 [dependencies]
 chrono = { version = "0.4.23", features = ["serde"], default-features = false, optional = true }
 futures-util = "0.3.17"
-http = "0.2.4"
+http = "1.3.1"
 influxdb_derive = { version = "0.5.1", optional = true }
 lazy-regex = "3.1"
-reqwest = { version = "0.11.4", default-features = false }
+reqwest = { version = "0.12.23", default-features = false }
 serde = { version = "1.0.186", optional = true }
 serde_derive = { version = "1.0.186", optional = true }
 serde_json = { version = "1.0.48", optional = true }
 surf = { version = "2.2.0", default-features = false, optional = true }
-thiserror = "1.0"
+thiserror = "2.0.16"
 time = { version = "0.3.39", optional = true }
 
 [features]
@@ -50,5 +50,5 @@ time = ["dep:time"]
 chrono = ["dep:chrono"]
 
 [dev-dependencies]
-indoc = "1.0"
+indoc = "2.0.6"
 tokio = { version = "1.7", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
## Description
Super minor change to update major versions of dependencies - `http`, `reqwest`, `thiserror`, `indoc`, and, for benchmarks, `tokio`.  There is a compile error in `benches/client.rs` and some clippy warnings in `influxdb/src/query/mod.rs`, but both exist without these updates; any breaking changes that exist in those crates don't impact `influxdb`

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy with reqwest feature: `cargo clippy --manifest-path influxdb/Cargo.toml --all-targets --no-default-features --features chrono,time,serde,derive,reqwest-client-rustls -- -D warnings`
- [x] Updated README.md using `cargo doc2readme -p influxdb --expand-macros`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment
